### PR TITLE
Changed request option

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ FTP client based on [LibCURL.jl](https://github.com/JuliaWeb/LibCURL.jl).
 
 Functions for non-persistent connection:
 ```julia
-ftp_get(url::String, file_name::String, options::RequestOptions, save_path::String)
-ftp_put(url::String, file_name::String, file::IO, options::RequestOptions)
-ftp_command(url::String, cmd::String, options::RequestOptions)
+ftp_get(file_name::String, options::RequestOptions, save_path::String)
+ftp_put(file_name::String, file::IO, options::RequestOptions)
+ftp_command(cmd::String, options::RequestOptions)
 ```
 - These functions all establish a connection, perform the desired operation then close the connection and return a `Response` object. Any data retrieved from server is in `Response.body`.
 
@@ -25,7 +25,7 @@ ftp_command(url::String, cmd::String, options::RequestOptions)
 
 Functions for persistent connection:
 ```julia
-ftp_connect(url::String, options::RequestOptions)
+ftp_connect(options::RequestOptions)
 ftp_get(ctxt::ConnContext, file_name::String, save_path::String)
 ftp_put(ctxt::ConnContext, file_name::String, file::IO)
 ftp_command(ctxt::ConnContext, cmd::String)
@@ -60,6 +60,7 @@ ftp_close_connection(ctxt::ConnContext)
         headers::Vector{Tuple}
         username::String
         passwd::String
+        url::String
     end
     ```
     - `blocking`: default is true
@@ -75,19 +76,19 @@ Using non-peristent connection and FTPS with implicit security:
 using FTPClient
 
 ftp_init()
-options = RequestOptions(ssl=true, implicit=true, username="user1", passwd="1234")
+options = RequestOptions(ssl=true, implicit=true, username="user1", passwd="1234", url="localhost")
 
-resp = ftp_get("localhost", "download_file.txt", options)
+resp = ftp_get("download_file.txt", options)
 io_buffer = resp.body
 
-resp = ftp_get("localhost", "download_file.txt", options, "Documents/downloaded_file.txt")
+resp = ftp_get("download_file.txt", options, "Documents/downloaded_file.txt")
 io_stream = resp.body
 
 file = open("upload_file.txt")
-resp = ftp_put("localhost", "upload_file.txt", file, options)
+resp = ftp_put("upload_file.txt", file, options)
 close(file)
 
-resp = ftp_command("localhost", "LIST", options)
+resp = ftp_command("LIST", options)
 dir = resp.body
 
 ftp_cleanup()
@@ -98,9 +99,9 @@ Using persistent connection and FTPS with explicit security:
 using FTPClient
 
 ftp_init()
-options = RequestOptions(ssl=true, username="user2", passwd="5678")
+options = RequestOptions(ssl=true, username="user2", passwd="5678", url="localhost")
 
-ctxt = ftp_connect("localhost", options)
+ctxt = ftp_connect(options)
 
 resp = ftp_get(ctxt, "download_file.txt")
 io_buffer = resp.body

--- a/src/FTPClient.jl
+++ b/src/FTPClient.jl
@@ -20,16 +20,21 @@ type RequestOptions
     username::String
     passwd::String
     url::String
+    hostname::String
 
-    function RequestOptions(; blocking=true, implicit=false, ssl=false, verify_peer=true, active_mode=false, username="", passwd="", url="localhost")
+    function RequestOptions(; blocking=true, implicit=false, ssl=false,
+            verify_peer=true, active_mode=false, username="",
+            passwd="", url=nothing, hostname="localhost")
 
-        if implicit
-            url = "ftps://" * String(url) * "/"
-        else
-            url = "ftp://"* String(url) * "/"
+        if url == nothing
+            if implicit
+                url = "ftps://" * String(hostname) * "/"
+            else
+                url = "ftp://"* String(hostname) * "/"
+            end
         end
 
-        new(blocking, implicit, ssl, verify_peer, active_mode, username, passwd, url)
+        new(blocking, implicit, ssl, verify_peer, active_mode, username, passwd, url, hostname)
     end
 end
 

--- a/src/FTPClient.jl
+++ b/src/FTPClient.jl
@@ -20,7 +20,9 @@ type RequestOptions
     username::String
     passwd::String
 
-    RequestOptions(; blocking=true, implicit=false, ssl=false, verify_peer=true, active_mode=false, username="", passwd="") = new(blocking, implicit, ssl, verify_peer, active_mode, username, passwd)
+    function RequestOptions(; blocking=true, implicit=false, ssl=false, verify_peer=true, active_mode=false, username="", passwd="")
+        new(blocking, implicit, ssl, verify_peer, active_mode, username, passwd)
+    end
 end
 
 type Response

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -14,8 +14,9 @@ type FTP
 
     function FTP(;host="", block=true, implt=false, ssl=false, ver_peer=true, act_mode=false, user="", pswd="")
         options = RequestOptions(blocking=block, implicit=implt, ssl=ssl,
-                    verify_peer=ver_peer,   active_mode=act_mode, username=user, passwd=pswd)
-        ctxt, resp = ftp_connect(host, options)
+                    verify_peer=ver_peer, active_mode=act_mode,
+                    username=user, passwd=pswd, url=host)
+        ctxt, resp = ftp_connect(options)
 
         if (resp.code == 226)
             new(ctxt)

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -15,7 +15,7 @@ type FTP
     function FTP(;host="", block=true, implt=false, ssl=false, ver_peer=true, act_mode=false, user="", pswd="")
         options = RequestOptions(blocking=block, implicit=implt, ssl=ssl,
                     verify_peer=ver_peer, active_mode=act_mode,
-                    username=user, passwd=pswd, url=host)
+                    username=user, passwd=pswd, hostname=host)
         ctxt, resp = ftp_connect(options)
 
         if (resp.code == 226)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,7 +30,7 @@ function set_command_response(request::String, code::Int64, reponse::String)
     @assert result == 1 "set_command_response failed"
 end
 
-url = "localhost"
+host = "localhost"
 user = "test"
 pswd = "test"
 home_dir = "/"
@@ -82,7 +82,7 @@ else
     set_file("/" * file_name, file_contents)
     set_command_response("AUTH", 230, "Login successful.")
     port = start_server()
-    url = "$url:$port"
+    host = "$host:$port"
 
     # Note: If LibCURL complains that the server doesn't listen it probably means that
     # the MockFtpServer isn't ready to accept connections yet.

--- a/test/test_explicit_ssl.jl
+++ b/test/test_explicit_ssl.jl
@@ -11,7 +11,7 @@ options = RequestOptions(ssl=true, implicit=false, active_mode=false, verify_pee
 println("Test non-persistent connection using ssl, explicit security and passive mode:\n")
 
 # test 1, download file from server
-resp = ftp_get(url, file_name, options)
+resp = ftp_get(file_name, options)
 @test resp.code == 226
 println("Test 1 passed.\n$resp")
 # rm(file_name)
@@ -19,7 +19,7 @@ println("Test 1 passed.\n$resp")
 # test 2, upload file to server
 try
     file = open(upload_file)
-    resp = ftp_put(url, "test_upload.txt", file, options)
+    resp = ftp_put("test_upload.txt", file, options)
     @test resp.code ==226
     println("Test 2 passed.\n$resp")
     close(file)
@@ -28,7 +28,7 @@ catch e
 end
 
 # test 3, pass command to server
-resp = ftp_command(url, "PWD", options)
+resp = ftp_command("PWD", options)
 @test resp.code == 257
 println("Test 3 passed.\n$resp")
 
@@ -40,7 +40,7 @@ options = RequestOptions(ssl=true, implicit=false, active_mode=true, verify_peer
 println("Test non-persistent connection using ssl, explicit security and active mode:\n")
 
 # test 4, download file from server
-resp = ftp_get(url, file_name, options)
+resp = ftp_get(file_name, options)
 @test resp.code == 226
 println("Test 4 passed.\n$resp")
 # rm(file_name)
@@ -48,7 +48,7 @@ println("Test 4 passed.\n$resp")
 # test 5, upload file to server
 try
     file = open(upload_file)
-    resp = ftp_put(url, "test_upload.txt", file, options)
+    resp = ftp_put("test_upload.txt", file, options)
     @test resp.code ==226
     println("Test 5 passed.\n$resp")
     close(file)
@@ -57,7 +57,7 @@ catch e
 end
 
 # test 6, pass command to server
-resp = ftp_command(url, "PWD", options)
+resp = ftp_command("PWD", options)
 @test resp.code == 257
 println("Test 6 passed.\n$resp")
 
@@ -69,7 +69,7 @@ options = RequestOptions(ssl=true, implicit=false, active_mode=false, verify_pee
 println("Test persistent connection using ssl, explicit security and passive mode:\n")
 
 # test 7, establish connection
-ctxt, resp = ftp_connect(url, options)
+ctxt, resp = ftp_connect(options)
 @test resp.code == 226
 println("Test 7 passed.\n$(resp)")
 
@@ -105,7 +105,7 @@ options = RequestOptions(ssl=true, implicit=false, active_mode=true, verify_peer
 println("Test persistent connection using ssl, explicit security and active mode:\n")
 
 # test 11, establish connection
-ctxt, resp = ftp_connect(url, options)
+ctxt, resp = ftp_connect(options)
 @test resp.code == 226
 println("Test 11 passed.\n$(resp)")
 

--- a/test/test_implicit_ssl.jl
+++ b/test/test_implicit_ssl.jl
@@ -11,7 +11,7 @@ options = RequestOptions(ssl=true, implicit=true, active_mode=false, verify_peer
 println("Test non-persistent connection using ssl, implicit security and passive mode:\n")
 
 # test 1, download file from server
-resp = ftp_get(url, file_name, options)
+resp = ftp_get(file_name, options)
 @test resp.code == 226
 println("Test 1 passed.\n$resp")
 # rm(file_name)
@@ -19,7 +19,7 @@ println("Test 1 passed.\n$resp")
 # test 2, upload file to server
 try
     file = open(upload_file)
-    resp = ftp_put(url, "test_upload.txt", file, options)
+    resp = ftp_put("test_upload.txt", file, options)
     @test resp.code ==226
     println("Test 2 passed.\n$resp")
     close(file)
@@ -28,7 +28,7 @@ catch e
 end
 
 # test 3, pass command to server
-resp = ftp_command(url, "PWD", options)
+resp = ftp_command("PWD", options)
 @test resp.code == 257
 println("Test 3 passed.\n$resp")
 
@@ -40,7 +40,7 @@ options = RequestOptions(ssl=true, implicit=true, active_mode=true, verify_peer=
 println("Test non-persistent connection using ssl, implicit security and active mode:\n")
 
 # test 4, download file from server
-resp = ftp_get(url, file_name, options)
+resp = ftp_get(file_name, options)
 @test resp.code == 226
 println("Test 4 passed.\n$resp")
 # rm(file_name)
@@ -48,7 +48,7 @@ println("Test 4 passed.\n$resp")
 # test 5, upload file to server
 try
     file = open(upload_file)
-    resp = ftp_put(url, "test_upload.txt", file, options)
+    resp = ftp_put("test_upload.txt", file, options)
     @test resp.code ==226
     println("Test 5 passed.\n$resp")
     close(file)
@@ -57,7 +57,7 @@ catch e
 end
 
 # test 6, pass command to server
-resp = ftp_command(url, "PWD", options)
+resp = ftp_command("PWD", options)
 @test resp.code == 257
 println("Test 6 passed.\n$resp")
 
@@ -69,7 +69,7 @@ options = RequestOptions(ssl=true, implicit=true, active_mode=false, verify_peer
 println("Test persistent connection using ssl, implicit security and passive mode:\n")
 
 # test 7, establish connection
-ctxt, resp = ftp_connect(url, options)
+ctxt, resp = ftp_connect(options)
 @test resp.code == 226
 println("Test 7 passed.\n$(resp)")
 
@@ -105,7 +105,7 @@ options = RequestOptions(ssl=true, implicit=true, active_mode=true, verify_peer=
 println("Test persistent connection using ssl, implicit security and active mode:\n")
 
 # test 11, establish connection
-ctxt, resp = ftp_connect(url, options)
+ctxt, resp = ftp_connect(options)
 @test resp.code == 226
 println("Test 11 passed.\n$(resp)")
 

--- a/test/test_non_ssl.jl
+++ b/test/test_non_ssl.jl
@@ -8,7 +8,7 @@ ftp_init()
 # Non-persistent connection tests, passive mode
 ###############################################################################
 
-options = RequestOptions(ssl=false, active_mode=false, username=user, passwd=pswd, url=url)
+options = RequestOptions(ssl=false, active_mode=false, username=user, passwd=pswd, hostname=host)
 println("\nTest non-persistent connection with passive mode:\n")
 
 # test 1, download file from server
@@ -33,7 +33,7 @@ println("\nTest 3 passed.\n$resp")
 # Non-persistent connection tests, active mode
 ###############################################################################
 
-options = RequestOptions(ssl=false, active_mode=true, username=user, passwd=pswd, url=url)
+options = RequestOptions(ssl=false, active_mode=true, username=user, passwd=pswd, hostname=host)
 println("\nTest non-persistent connection with active mode:\n")
 
 # test 4, download file from server
@@ -58,7 +58,7 @@ println("\nTest 6 passed.\n$resp")
 # Persistent connection tests, passive mode
 ###############################################################################
 
-options = RequestOptions(ssl=false, active_mode=false, username=user, passwd=pswd, url=url)
+options = RequestOptions(ssl=false, active_mode=false, username=user, passwd=pswd, hostname=host)
 println("\nTest persistent connection with passive mode:\n")
 
 # test 7, establish connection
@@ -90,7 +90,7 @@ close(file)
 # Persistent connection tests, active mode
 ###############################################################################
 
-options = RequestOptions(ssl=false, active_mode=true, username=user, passwd=pswd, url=url)
+options = RequestOptions(ssl=false, active_mode=true, username=user, passwd=pswd, hostname=host)
 println("\nTest persistent connection with active mode:\n")
 
 # test 11, establish connection

--- a/test/test_non_ssl.jl
+++ b/test/test_non_ssl.jl
@@ -8,24 +8,24 @@ ftp_init()
 # Non-persistent connection tests, passive mode
 ###############################################################################
 
-options = RequestOptions(ssl=false, active_mode=false, username=user, passwd=pswd)
+options = RequestOptions(ssl=false, active_mode=false, username=user, passwd=pswd, url=url)
 println("\nTest non-persistent connection with passive mode:\n")
 
 # test 1, download file from server
-resp = ftp_get(url, file_name, options)
+resp = ftp_get(file_name, options)
 @test resp.code == 226
 println("\nTest 1 passed.\n$resp")
 # rm(file_name)
 
 # test 2, upload file to server
 file = open(upload_file)
-resp = ftp_put(url, "test_upload.txt", file, options)
+resp = ftp_put("test_upload.txt", file, options)
 @test resp.code ==226
 println("\nTest 2 passed.\n$resp")
 close(file)
 
 # test 3, pass command to server
-resp = ftp_command(url, "PWD", options)
+resp = ftp_command("PWD", options)
 @test resp.code == 257
 println("\nTest 3 passed.\n$resp")
 
@@ -33,24 +33,24 @@ println("\nTest 3 passed.\n$resp")
 # Non-persistent connection tests, active mode
 ###############################################################################
 
-options = RequestOptions(ssl=false, active_mode=true, username=user, passwd=pswd)
+options = RequestOptions(ssl=false, active_mode=true, username=user, passwd=pswd, url=url)
 println("\nTest non-persistent connection with active mode:\n")
 
 # test 4, download file from server
-resp = ftp_get(url, file_name, options)
+resp = ftp_get(file_name, options)
 @test resp.code == 226
 println("\nTest 4 passed.\n$resp")
 # rm(file_name)
 
 # test 5, upload file to server
 file = open(upload_file)
-resp = ftp_put(url, "test_upload.txt", file, options)
+resp = ftp_put("test_upload.txt", file, options)
 @test resp.code ==226
 println("\nTest 5 passed.\n$resp")
 close(file)
 
 # test 6, pass command to server
-resp = ftp_command(url, "PWD", options)
+resp = ftp_command("PWD", options)
 @test resp.code == 257
 println("\nTest 6 passed.\n$resp")
 
@@ -58,11 +58,11 @@ println("\nTest 6 passed.\n$resp")
 # Persistent connection tests, passive mode
 ###############################################################################
 
-options = RequestOptions(ssl=false, active_mode=false, username=user, passwd=pswd)
+options = RequestOptions(ssl=false, active_mode=false, username=user, passwd=pswd, url=url)
 println("\nTest persistent connection with passive mode:\n")
 
 # test 7, establish connection
-ctxt, resp = ftp_connect(url, options)
+ctxt, resp = ftp_connect(options)
 @test resp.code == 226
 println("\nTest 7 passed.\n$(resp)")
 
@@ -90,11 +90,11 @@ close(file)
 # Persistent connection tests, active mode
 ###############################################################################
 
-options = RequestOptions(ssl=false, active_mode=true, username=user, passwd=pswd)
+options = RequestOptions(ssl=false, active_mode=true, username=user, passwd=pswd, url=url)
 println("\nTest persistent connection with active mode:\n")
 
 # test 11, establish connection
-ctxt, resp = ftp_connect(url, options)
+ctxt, resp = ftp_connect(options)
 @test resp.code == 226
 println("\nTest 11 passed.\n$(resp)")
 


### PR DESCRIPTION
I move the `url` string into the `RequestOption` struct. We were often passing both the option and the url so it makes things easier this way.
