### PR TITLE
Close should return nothing

### DIFF
--- a/src/FTPC.jl
+++ b/src/FTPC.jl
@@ -574,6 +574,7 @@ Close the connection to the FTP server.
 """
 function ftp_close_connection(ctxt::ConnContext)
     cleanup_easy_context(ctxt)
+    nothing
 end
 
 


### PR DESCRIPTION
Avoids having `close(::FTP)` return a `Ptr`