### PR TITLE
URL constructors and port keywords

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
 julia:
   - 0.6
   - nightly
+env:
+  - CONDA_JL_VERSION="2"
 matrix:
   allow_failures:
       - julia: nightly

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.6
 LibCURL 0.2.2
+URIParser
 Compat 0.47

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
 LibCURL 0.2.2
 URIParser
-Compat 0.47
+Compat 0.59

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,5 @@
 environment:
+  CONDA_JL_VERSION: 2
   matrix:
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"

--- a/src/FTPC.jl
+++ b/src/FTPC.jl
@@ -84,7 +84,6 @@ function security(opts::RequestOptions)
     opts.ssl ? (opts.uri.scheme == "ftps" ? :implicit : :explicit) : :none
 end
 
-username(opts::RequestOptions) = first(split(opts.uri.userinfo, ':', limit=2))
 ispassive(opts::RequestOptions) = !opts.active_mode
 
 
@@ -148,7 +147,9 @@ mutable struct ConnContext
     url::String  # Avoid using an abstract type when interacting with C libraries
     options::RequestOptions
 
-    ConnContext(options::RequestOptions) = new(C_NULL, string(options.uri), options)
+    function ConnContext(options::RequestOptions)
+        new(C_NULL, rstrip(string(options.uri), '/'), options)
+    end
 end
 
 

--- a/src/FTPC.jl
+++ b/src/FTPC.jl
@@ -1,5 +1,5 @@
 using Compat
-using Compat: Cvoid, uninitialized
+using Compat: Cvoid, undef
 using LibCURL
 
 import Base: ==
@@ -188,7 +188,7 @@ function curl_read_cb(out::Ptr{Cvoid}, s::Csize_t, n::Csize_t, p_rd::Ptr{Cvoid})
     breq::Csize_t = rd.sz - rd.offset
     b2copy = bavail > breq ? breq : bavail
 
-    b_read = Array{UInt8}(uninitialized, b2copy)
+    b_read = Array{UInt8}(undef, b2copy)
     read!(rd.src, b_read)
 
     ccall(:memcpy, Ptr{Cvoid}, (Ptr{Cvoid}, Ptr{Cvoid}, UInt), out, b_read, b2copy)

--- a/src/FTPC.jl
+++ b/src/FTPC.jl
@@ -44,7 +44,7 @@ function RequestOptions(;
 )
     if isempty(url)
         scheme = implicit ? "ftps" : "ftp"
-        url = "$scheme://$hostname/"
+        url = "$scheme://$hostname"
     end
 
     RequestOptions(url, username, password, ssl, verify_peer, active_mode)
@@ -355,7 +355,7 @@ function ftp_get(
 
         @ce_curl curl_easy_setopt CURLOPT_PROXY_TRANSFER_MODE Int64(1)
 
-        full_url = ctxt.url * file_name
+        full_url = ctxt.url * "/" * file_name
         if mode == binary_mode
             @ce_curl curl_easy_setopt CURLOPT_URL full_url * ";type=i"
         elseif mode == ascii_mode
@@ -464,7 +464,7 @@ function ftp_put(
     @ce_curl curl_easy_setopt CURLOPT_READDATA p_rd
     @ce_curl curl_easy_setopt CURLOPT_READFUNCTION C_CURL_READ_CB[]
 
-    @ce_curl curl_easy_setopt CURLOPT_URL ctxt.url * file_name
+    @ce_curl curl_easy_setopt CURLOPT_URL ctxt.url * "/" * file_name
 
     if mode == binary_mode
         @ce_curl curl_easy_setopt CURLOPT_TRANSFERTEXT Int64(0)
@@ -538,9 +538,9 @@ function ftp_command(
     resp.body = seekstart(wd.buffer)
     resp.bytes_recd = wd.bytes_recd
 
-    cmd = split(cmd)
-    if resp.code == 250 && cmd[1] == "CWD"
-        ctxt.url *= join(cmd[2:end], ' ')
+    parts = split(cmd, ' ', limit=2)
+    if resp.code == 250 && parts[1] == "CWD"
+        ctxt.url *= "/" * rstrip(parts[2], '/')
     end
 
     return resp

--- a/src/FTPC.jl
+++ b/src/FTPC.jl
@@ -148,7 +148,7 @@ mutable struct ConnContext
     options::RequestOptions
 
     function ConnContext(options::RequestOptions)
-        new(C_NULL, rstrip(string(options.uri), '/'), options)
+        new(C_NULL, trailing(string(options.uri), '/'), options)
     end
 end
 
@@ -379,7 +379,7 @@ function ftp_get(
 
         @ce_curl curl_easy_setopt CURLOPT_PROXY_TRANSFER_MODE Int64(1)
 
-        full_url = ctxt.url * "/" * file_name
+        full_url = ctxt.url * file_name
         if mode == binary_mode
             @ce_curl curl_easy_setopt CURLOPT_URL full_url * ";type=i"
         elseif mode == ascii_mode
@@ -488,7 +488,7 @@ function ftp_put(
     @ce_curl curl_easy_setopt CURLOPT_READDATA p_rd
     @ce_curl curl_easy_setopt CURLOPT_READFUNCTION C_CURL_READ_CB[]
 
-    @ce_curl curl_easy_setopt CURLOPT_URL ctxt.url * "/" * file_name
+    @ce_curl curl_easy_setopt CURLOPT_URL ctxt.url * file_name
 
     if mode == binary_mode
         @ce_curl curl_easy_setopt CURLOPT_TRANSFERTEXT Int64(0)
@@ -564,7 +564,7 @@ function ftp_command(
 
     parts = split(cmd, ' ', limit=2)
     if resp.code == 250 && parts[1] == "CWD"
-        ctxt.url *= "/" * rstrip(parts[2], '/')
+        ctxt.url *= trailing(parts[2], '/')
     end
 
     return resp

--- a/src/FTPC.jl
+++ b/src/FTPC.jl
@@ -34,6 +34,7 @@ The options used to connect to an FTP server.
 """
 function RequestOptions(;
     hostname::AbstractString="localhost",
+    port::Integer=0,
     username::AbstractString="",
     password::AbstractString="",
     ssl::Bool=false,
@@ -45,6 +46,7 @@ function RequestOptions(;
     if isempty(url)
         scheme = implicit ? "ftps" : "ftp"
         url = "$scheme://$hostname"
+        port > 0 && (url *= ":$port")
     end
 
     RequestOptions(url, username, password, ssl, verify_peer, active_mode)

--- a/src/FTPC.jl
+++ b/src/FTPC.jl
@@ -18,22 +18,21 @@ struct RequestOptions
 end
 
 """
-    RequestOptions(;kwargs)
+    RequestOptions(; kwargs...)
 
 The options used to connect to an FTP server.
 
-# Parameters
-* `implicit::Bool=false`: use implicit security.
-* `ssl::Bool=false`: use FTPS.
-* `verify_peer::Bool=true`: verify authenticity of peer's certificate.
-* `active_mode::Bool=false`: use active mode to establish data connection.
-* `username::AbstractString=""`: the username used to access the FTP server.
-* `password::AbstractString=""`: the password used to access the FTP server.
-* `url::AbstractString=""`: the url of the FTP server.
-* `hostname::AbstractString="localhost"`: the hostname or address of the FTP server.
+# Keywords
+- `hostname::AbstractString="localhost"`: the hostname or address of the FTP server.
+- `username::AbstractString=""`: the username used to access the FTP server.
+- `password::AbstractString=""`: the password used to access the FTP server.
+- `implicit::Bool=false`: use an implicit FTPS configuration.
+- `ssl::Bool=false`: use a secure connection. Typically specified for explicit FTPS.
+- `verify_peer::Bool=true`: verify authenticity of peer's certificate.
+- `active_mode::Bool=false`: use active mode to establish data connection.
+- `url::AbstractString=""`: the URL of the FTP server. Can be used to specify the port.
 """
 function RequestOptions(;
-    url::AbstractString="",
     hostname::AbstractString="localhost",
     username::AbstractString="",
     password::AbstractString="",
@@ -41,6 +40,7 @@ function RequestOptions(;
     implicit::Bool=false,
     verify_peer::Bool=true,
     active_mode::Bool=false,
+    url::AbstractString="",  # TODO: deprecate when we support this functionality elsewhere
 )
     if isempty(url)
         scheme = implicit ? "ftps" : "ftp"

--- a/src/FTPClient.jl
+++ b/src/FTPClient.jl
@@ -5,6 +5,7 @@ module FTPClient
 import Base: convert, show, open, mkdir, ascii, mv
 import Base: readdir, cd, pwd, rm, close, download
 using Compat: unsafe_string, unsafe_write, @compat, Cvoid
+using URIParser: URI
 
 mutable struct FTPClientError <: Exception
     msg::AbstractString
@@ -45,6 +46,7 @@ function __init__()
     C_CURL_READ_CB[] = cfunction(curl_read_cb, Csize_t, Tuple{Ptr{Cvoid}, Csize_t, Csize_t, Ptr{Cvoid}})
 end
 
+include("utils.jl")
 include("FTPC.jl")
 include("FTPObject.jl")
 

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -94,8 +94,7 @@ end
 function show(io::IO, ftp::FTP)
     opts = ftp.ctxt.options
     join(io, [
-        "Host:      $(safe_uri(ftp.ctxt.url))",
-        "User:      $(username(opts))",
+        "URL:       $(safe_uri(ftp.ctxt.url))",
         "Transfer:  $(ispassive(opts) ? "passive" : "active") mode",
         "Security:  $(security(opts))",
     ], "\n")

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -1,49 +1,57 @@
 # FTP code for when the file transfer is complete.
 const complete_transfer_code = 226
 
+
+struct FTP
+    ctxt::ConnContext
+end
+
+function FTP(options::RequestOptions; verbose::Union{Bool,IOStream}=false)
+    try
+        ctxt, resp = ftp_connect(options; verbose=verbose)
+        FTP(ctxt)
+    catch err
+        if isa(err, FTPClientError)
+            err.msg = "Failed to connect."
+        end
+        rethrow()
+    end
+end
+
 """
     FTP(; kwargs...) -> FTP
 
 Create an FTP object.
 
-# Arguments
-* `hostname::AbstractString=""`: the hostname or address of the FTP server.
-* `implicit::Bool=false`: use implicit security.
-* `ssl::Bool=false`: use FTPS.
-* `verify_peer::Bool=true`: verify authenticity of peer's certificate.
-* `active_mode::Bool=false`: use active mode to establish data connection.
-* `username::AbstractString=""`: the username used to access the FTP server.
-* `password::AbstractString=""`: the password used to access the FTP server.
-* `verbose::Union{Bool,IOStream}=false`: an `IOStream` to capture LibCurl's output or a
+# Keywords
+- `hostname::AbstractString=""`: the hostname or address of the FTP server.
+- `username::AbstractString=""`: the username used to access the FTP server.
+- `password::AbstractString=""`: the password used to access the FTP server.
+- `ssl::Bool=false`: use FTPS.
+- `implicit::Bool=false`: use implicit security.
+- `verify_peer::Bool=true`: verify authenticity of peer's certificate.
+- `active_mode::Bool=false`: use active mode to establish data connection.
+- `verbose::Union{Bool,IOStream}=false`: an `IOStream` to capture LibCurl's output or a
     `Bool`, if true output is written to STDERR.
+- `url::AbstractString=""`: the URL of the FTP server. Can be used to specify the port.
 """
-mutable struct FTP
-    ctxt::ConnContext
-
-    function FTP(;
-        hostname::AbstractString="", implicit::Bool=false, ssl::Bool=false,
-        verify_peer::Bool=true, active_mode::Bool=false, username::AbstractString="",
-        password::AbstractString="", url::AbstractString="",
-        verbose::Union{Bool,IOStream}=false,
+function FTP(;
+    hostname::AbstractString="",
+    username::AbstractString="",
+    password::AbstractString="",
+    ssl::Bool=false,
+    implicit::Bool=false,
+    verify_peer::Bool=true,
+    active_mode::Bool=false,
+    verbose::Union{Bool,IOStream}=false,
+    url::AbstractString="",  # TODO: deprecate when we support this functionality elsewhere
+)
+    options = RequestOptions(
+        username=username, password=password, hostname=hostname, url=url,
+        ssl=ssl, implicit=implicit, verify_peer=verify_peer, active_mode=active_mode,
     )
-        options = RequestOptions(
-            implicit=implicit, ssl=ssl,
-            verify_peer=verify_peer, active_mode=active_mode,
-            username=username, password=password, hostname=hostname, url=url
-        )
 
-        ctxt = nothing
-        try
-            ctxt, resp = ftp_connect(options; verbose=verbose)
-        catch err
-            if isa(err, FTPClientError)
-                err.msg = "Failed to connect."
-            end
-            rethrow()
-        end
-
-        new(ctxt)
-    end
+    FTP(options; verbose=verbose)
 end
 
 function show(io::IO, ftp::FTP)

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -27,13 +27,12 @@ Create an FTP object.
 - `hostname::AbstractString=""`: the hostname or address of the FTP server.
 - `username::AbstractString=""`: the username used to access the FTP server.
 - `password::AbstractString=""`: the password used to access the FTP server.
-- `ssl::Bool=false`: use FTPS.
-- `implicit::Bool=false`: use implicit security.
+- `ssl::Bool=false`: use a secure FTP connection.
+- `implicit::Bool=false`: use implicit security (FTPS).
 - `verify_peer::Bool=true`: verify authenticity of peer's certificate.
 - `active_mode::Bool=false`: use active mode to establish data connection.
 - `verbose::Union{Bool,IOStream}=false`: an `IOStream` to capture LibCurl's output or a
     `Bool`, if true output is written to STDERR.
-- `url::AbstractString=""`: the URL of the FTP server. Can be used to specify the port.
 """
 function FTP(;
     hostname::AbstractString="",
@@ -47,11 +46,48 @@ function FTP(;
     verbose::Union{Bool,IOStream}=false,
     url::AbstractString="",  # TODO: deprecate when we support this functionality elsewhere
 )
+    if !isempty(url)
+        Base.depwarn(string(
+            "Using `FTP` with the `url` keyword is deprecated; ",
+            "use `FTP(url, ...)` instead",
+        ), :FTP)
+    end
+
     options = RequestOptions(
         username=username, password=password, hostname=hostname, port=port, url=url,
         ssl=ssl, implicit=implicit, verify_peer=verify_peer, active_mode=active_mode,
     )
 
+    FTP(options; verbose=verbose)
+end
+
+"""
+    FTP(url; kwargs...)
+
+Connect to an FTP server using the information specified in the URI.
+
+# Keywords
+- `ssl::Bool=false`: use a secure FTP connection.
+- `verify_peer::Bool=true`: verify the authenticity of the peer's certificate.
+- `active_mode::Bool=false`: use active mode to establish data connection.
+
+# Example
+```julia
+julia> FTP("ftp://user:password@ftp.example.com");  # FTP connection with no security
+
+julia> FTP("ftp://user:password@ftp.example.com", ssl=true);  # Explicit security (FTPES)
+
+julia> FTP("ftps://user:password@ftp.example.com");  # Implicit security (FTPS)
+```
+"""
+function FTP(
+    url::AbstractString;
+    ssl::Bool=false,
+    verify_peer::Bool=true,
+    active_mode::Bool=false,
+    verbose::Union{Bool,IOStream}=false,
+)
+    options = RequestOptions(url; ssl=ssl, verify_peer=verify_peer, active_mode=active_mode)
     FTP(options; verbose=verbose)
 end
 

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -299,10 +299,6 @@ end
 Set the current working directory of the FTP server to "dir".
 """
 function cd(ftp::FTP, dir::AbstractString; verbose::Union{Bool,IOStream}=false)
-    if !endswith(dir, "/")
-        dir *= "/"
-    end
-
     resp = ftp_command(ftp.ctxt, "CWD $dir"; verbose=verbose)
 
     if resp.code != 250

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -37,6 +37,7 @@ Create an FTP object.
 """
 function FTP(;
     hostname::AbstractString="",
+    port::Integer=0,
     username::AbstractString="",
     password::AbstractString="",
     ssl::Bool=false,
@@ -47,7 +48,7 @@ function FTP(;
     url::AbstractString="",  # TODO: deprecate when we support this functionality elsewhere
 )
     options = RequestOptions(
-        username=username, password=password, hostname=hostname, url=url,
+        username=username, password=password, hostname=hostname, port=port, url=url,
         ssl=ssl, implicit=implicit, verify_peer=verify_peer, active_mode=active_mode,
     )
 
@@ -406,13 +407,13 @@ Execute Function "code" on FTP server.
 """
 function ftp(
     code::Function;
-    hostname::AbstractString="", implicit::Bool=false, ssl::Bool=false,
+    hostname::AbstractString="", port::Integer=0, implicit::Bool=false, ssl::Bool=false,
     verify_peer::Bool=true, active_mode::Bool=false, username::AbstractString="",
     password::AbstractString="", verbose::Union{Bool,IOStream}=false,
 )
     ftp_init()
     ftp_client = FTP(
-        hostname=hostname, implicit=implicit, ssl=ssl, verify_peer=verify_peer,
+        hostname=hostname, port=port, implicit=implicit, ssl=ssl, verify_peer=verify_peer,
         active_mode=active_mode, username=username, password=password, verbose=verbose,
     )
 

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -58,7 +58,7 @@ end
 function show(io::IO, ftp::FTP)
     opts = ftp.ctxt.options
     join(io, [
-        "Host:      $(ftp.ctxt.url)",
+        "Host:      $(safe_uri(ftp.ctxt.url))",
         "User:      $(username(opts))",
         "Transfer:  $(ispassive(opts) ? "passive" : "active") mode",
         "Security:  $(security(opts))",

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -11,3 +11,7 @@ function safe_uri(uri::URI)
 end
 
 safe_uri(uri::AbstractString) = string(safe_uri(URI(uri)))
+
+function trailing(str::AbstractString, tail::Char)
+    endswith(str, tail) ? str : string(str, tail)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,13 @@
+function safe_uri(uri::URI)
+    parts = split(uri.userinfo, ':', limit=2)
+
+    userinfo = if length(parts) > 1
+        parts[1] * ":*****"
+    else
+        parts[1]
+    end
+
+    URI(uri; userinfo=userinfo)
+end
+
+safe_uri(uri::AbstractString) = string(safe_uri(URI(uri)))

--- a/test/ftp_object.jl
+++ b/test/ftp_object.jl
@@ -13,14 +13,14 @@ opts = (
 function no_unexpected_changes(ftp::FTP, hostname::AbstractString=hostname(server))
     other = FTP(; opts...)
     @test ftp.ctxt.options == other.ctxt.options
-    @test ftp.ctxt.url == "ftp://$hostname/"
+    @test ftp.ctxt.url == "ftp://$hostname"
     close(other)
 end
 
 function expected_output(active::Bool)
     mode = active ? "active" : "passive"
     expected = """
-        Host:      ftp://$(hostname(server))/
+        Host:      ftp://$(hostname(server))
         User:      $(username(server))
         Transfer:  $mode mode
         Security:  none

--- a/test/ftp_object.jl
+++ b/test/ftp_object.jl
@@ -22,8 +22,7 @@ end
 function expected_output(active::Bool)
     mode = active ? "active" : "passive"
     expected = """
-        Host:      $(FTPClient.safe_uri(prefix))
-        User:      $(username(server))
+        URL:       $(FTPClient.safe_uri(prefix))
         Transfer:  $mode mode
         Security:  none
         """
@@ -99,7 +98,6 @@ end
         hostname(server),
         ":",
         port(server),
-        "/",
     )
 
     ftp = FTP(url; ssl=false)

--- a/test/ftp_object.jl
+++ b/test/ftp_object.jl
@@ -90,9 +90,20 @@ end
 end
 
 @testset "connection with url" begin
-    url = "ftp://$(hostname(server)):$(port(server))/"
-    ftp = FTP(; url=url, opts...)
-    @test ftp.ctxt.url == prefix * "/"
+    url = string(
+        "ftp://",
+        username(server),
+        ":",
+        password(server),
+        "@",
+        hostname(server),
+        ":",
+        port(server),
+        "/",
+    )
+
+    ftp = FTP(url; ssl=false)
+    @test ftp.ctxt.url == url
     close(ftp)
 end
 

--- a/test/ftp_object.jl
+++ b/test/ftp_object.jl
@@ -12,7 +12,6 @@ opts = (
 )
 
 
-
 function no_unexpected_changes(ftp::FTP, url::AbstractString=prefix)
     other = FTP(; opts...)
     @test ftp.ctxt.options == other.ctxt.options
@@ -23,7 +22,7 @@ end
 function expected_output(active::Bool)
     mode = active ? "active" : "passive"
     expected = """
-        Host:      $prefix
+        Host:      $(FTPClient.safe_uri(prefix))
         User:      $(username(server))
         Transfer:  $mode mode
         Security:  none
@@ -93,7 +92,7 @@ end
 @testset "connection with url" begin
     url = "ftp://$(hostname(server)):$(port(server))/"
     ftp = FTP(; url=url, opts...)
-    @test ftp.ctxt.url == url
+    @test ftp.ctxt.url == prefix * "/"
     close(ftp)
 end
 

--- a/test/ftp_object.jl
+++ b/test/ftp_object.jl
@@ -12,7 +12,7 @@ opts = (
 )
 
 
-function no_unexpected_changes(ftp::FTP, url::AbstractString=prefix)
+function no_unexpected_changes(ftp::FTP, url::AbstractString=FTPClient.trailing(prefix, '/'))
     other = FTP(; opts...)
     @test ftp.ctxt.options == other.ctxt.options
     @test ftp.ctxt.url == url
@@ -98,6 +98,7 @@ end
         hostname(server),
         ":",
         port(server),
+        "/",
     )
 
     ftp = FTP(url; ssl=false)
@@ -180,7 +181,7 @@ end
     ftp = FTP(; opts...)
     mkdir(server_dir)
     cd(ftp, testdir)
-    no_unexpected_changes(ftp, "$prefix/$testdir")
+    no_unexpected_changes(ftp, "$prefix/$testdir/")
     cleanup_dir(server_dir)
     close(ftp)
 
@@ -199,7 +200,7 @@ end
     @test isdir(server_dir)
     cd(ftp, testdir)
     cd(ftp, "..")
-    no_unexpected_changes(ftp, "$prefix/$testdir/..")
+    no_unexpected_changes(ftp, "$prefix/$testdir/../")
     cleanup_dir(server_dir)
     close(ftp)
 end
@@ -499,7 +500,7 @@ end
         test_captured_ouput() do io
             cd(ftp, testdir; verbose=io)
         end
-        no_unexpected_changes(ftp, "$prefix/$testdir")
+        no_unexpected_changes(ftp, "$prefix/$testdir/")
         cleanup_dir(server_dir)
         close(ftp)
     end

--- a/test/non_ssl.jl
+++ b/test/non_ssl.jl
@@ -154,7 +154,7 @@ function tests_by_mode(active::Bool)
     @test resp.bytes_recd == length(body)
     @test resp.code == 226
     @test is_headers_equal(resp.headers, headers)
-    @test ctxt.url == options.url == "ftp://$(hostname(server))/"
+    @test ctxt.url == options.url == "ftp://$(hostname(server))"
     @test ctxt.options == options
     ftp_close_connection(ctxt)
 
@@ -166,7 +166,7 @@ function tests_by_mode(active::Bool)
     ctxt, resp = ftp_connect(options)
     test_command(headers, ctxt)
 
-    @test ctxt.url == options.url == "ftp://$(hostname(server))/"
+    @test ctxt.url == options.url == "ftp://$(hostname(server))"
     @test ctxt.options == options
     ftp_close_connection(ctxt)
 
@@ -180,7 +180,7 @@ function tests_by_mode(active::Bool)
     ctxt, resp = ftp_connect(options)
     test_get(headers, ctxt)
 
-    @test ctxt.url == options.url == "ftp://$(hostname(server))/"
+    @test ctxt.url == options.url == "ftp://$(hostname(server))"
     @test ctxt.options == options
     ftp_close_connection(ctxt)
 

--- a/test/non_ssl.jl
+++ b/test/non_ssl.jl
@@ -155,7 +155,7 @@ function tests_by_mode(active::Bool)
     @test resp.bytes_recd == length(body)
     @test resp.code == 226
     @test is_headers_equal(resp.headers, headers)
-    @test ctxt.url == string(options.uri) == prefix
+    @test rstrip(ctxt.url, '/') == string(options.uri) == prefix
     @test ctxt.options == options
     ftp_close_connection(ctxt)
 
@@ -167,7 +167,7 @@ function tests_by_mode(active::Bool)
     ctxt, resp = ftp_connect(options)
     test_command(headers, ctxt)
 
-    @test ctxt.url == string(options.uri) == prefix
+    @test rstrip(ctxt.url, '/') == string(options.uri) == prefix
     @test ctxt.options == options
     ftp_close_connection(ctxt)
 
@@ -181,7 +181,7 @@ function tests_by_mode(active::Bool)
     ctxt, resp = ftp_connect(options)
     test_get(headers, ctxt)
 
-    @test ctxt.url == string(options.uri) == prefix
+    @test rstrip(ctxt.url, '/') == string(options.uri) == prefix
     @test ctxt.options == options
     ftp_close_connection(ctxt)
 

--- a/test/non_ssl.jl
+++ b/test/non_ssl.jl
@@ -155,7 +155,7 @@ function tests_by_mode(active::Bool)
     @test resp.bytes_recd == length(body)
     @test resp.code == 226
     @test is_headers_equal(resp.headers, headers)
-    @test ctxt.url == options.url == prefix
+    @test ctxt.url == string(options.uri) == prefix
     @test ctxt.options == options
     ftp_close_connection(ctxt)
 
@@ -167,7 +167,7 @@ function tests_by_mode(active::Bool)
     ctxt, resp = ftp_connect(options)
     test_command(headers, ctxt)
 
-    @test ctxt.url == options.url == prefix
+    @test ctxt.url == string(options.uri) == prefix
     @test ctxt.options == options
     ftp_close_connection(ctxt)
 
@@ -181,7 +181,7 @@ function tests_by_mode(active::Bool)
     ctxt, resp = ftp_connect(options)
     test_get(headers, ctxt)
 
-    @test ctxt.url == options.url == prefix
+    @test ctxt.url == string(options.uri) == prefix
     @test ctxt.options == options
     ftp_close_connection(ctxt)
 

--- a/test/non_ssl.jl
+++ b/test/non_ssl.jl
@@ -3,6 +3,7 @@ tempfile(joinpath(ROOT,download_file))
 
 opts = (
     :hostname => hostname(server),
+    :port => port(server),
     :username => username(server),
     :password => password(server),
 )
@@ -154,7 +155,7 @@ function tests_by_mode(active::Bool)
     @test resp.bytes_recd == length(body)
     @test resp.code == 226
     @test is_headers_equal(resp.headers, headers)
-    @test ctxt.url == options.url == "ftp://$(hostname(server))"
+    @test ctxt.url == options.url == prefix
     @test ctxt.options == options
     ftp_close_connection(ctxt)
 
@@ -166,7 +167,7 @@ function tests_by_mode(active::Bool)
     ctxt, resp = ftp_connect(options)
     test_command(headers, ctxt)
 
-    @test ctxt.url == options.url == "ftp://$(hostname(server))"
+    @test ctxt.url == options.url == prefix
     @test ctxt.options == options
     ftp_close_connection(ctxt)
 
@@ -180,7 +181,7 @@ function tests_by_mode(active::Bool)
     ctxt, resp = ftp_connect(options)
     test_get(headers, ctxt)
 
-    @test ctxt.url == options.url == "ftp://$(hostname(server))"
+    @test ctxt.url == options.url == prefix
     @test ctxt.options == options
     ftp_close_connection(ctxt)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,6 +8,7 @@ include("utils.jl")
 setup_server()
 ftp_init()
 server = FTPServer()
+prefix = "ftp://$(hostname(server)):$(port(server))"
 
 testdir = "test_dir"
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,7 +8,9 @@ include("utils.jl")
 setup_server()
 ftp_init()
 server = FTPServer()
-prefix = "ftp://$(hostname(server)):$(port(server))"
+
+# Note: port is always supplied with the test server
+prefix = "ftp://$(username(server)):$(password(server))@$(hostname(server)):$(port(server))"
 
 testdir = "test_dir"
 

--- a/test/server/server.jl
+++ b/test/server/server.jl
@@ -53,7 +53,7 @@ mutable struct FTPServer
             new(root, port, username, password, permissions, security, process, io)
         else
             kill(process)
-            error(line, bytestring(readavailable(io)))  # Display traceback
+            error(line, String(readavailable(io)))  # Display traceback
         end
     end
 end

--- a/test/server/server.jl
+++ b/test/server/server.jl
@@ -58,7 +58,7 @@ mutable struct FTPServer
     end
 end
 
-hostname(server::FTPServer) = "localhost:$(port(server))"
+hostname(server::FTPServer) = "localhost"
 port(server::FTPServer) = server.port
 username(server::FTPServer) = server.username
 password(server::FTPServer) = server.password

--- a/test/ssl.jl
+++ b/test/ssl.jl
@@ -7,6 +7,7 @@ function ssl_tests(implicit::Bool = true)
 
     opts = (
         :hostname => hostname(server),
+        :port => port(server),
         :username => username(server),
         :password => password(server),
         :ssl => true,


### PR DESCRIPTION
- Mostly adds new constructors which support passing in a URL as a parameter instead of a keyword (which is now deprecated). 
- Under the hood we're using URIs and applying credentials via [CURLOPT_URL](https://curl.haxx.se/libcurl/c/CURLOPT_URL.html) instead of CURLOPT_USERNAME/CURLOPT_PASSWORD. I had some trouble doing this as using an `AbstractString` doesn't work so well when interacting with C libraries.
- Added some handy utility functions: `safe_uri` which just masks the password so it's safe to display the URI. And `trailing` which I use to add a single trailing forward slash to the end of a string.