### PR TITLE
Add ssl environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ end
 - `verify_peer`: verify authenticity of peer's certificate, default is true
 - `active_mode`: use active mode to establish data connection, default is false
 
-Note: Can also specify `ENV["FTPS"] = true`. If either ssl=true or the environment variable `FTPS` is true ssl will be used
+Note: Can also specify explicit FTP with SSL `ENV["FTPES"] = true`. If either ssl=true or the environment variable `FTPES` is true ssl will be used
 
 
 #### FTPObject functions

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ end
 - `verify_peer`: verify authenticity of peer's certificate, default is true
 - `active_mode`: use active mode to establish data connection, default is false
 
+Note: Can also specify `ENV["FTPS"] = true`. If either ssl=true or the environment variable `FTPS` is true ssl will be used
+
 
 #### FTPObject functions
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
-LibCURL 0.2.2
+LibCURL 0.2.2 0.3
 URIParser
 Compat 0.59

--- a/src/FTPC.jl
+++ b/src/FTPC.jl
@@ -229,7 +229,7 @@ function setup_easy_handle(options::RequestOptions)
     @ce_curl curl_easy_setopt CURLOPT_URL ctxt.url
     # @ce_curl curl_easy_setopt CURLOPT_VERBOSE Int64(1)
 
-    if options.ssl
+    if options.ssl || parse(Bool, get(ENV, "FTPS", "false"))
         @ce_curl curl_easy_setopt CURLOPT_USE_SSL CURLUSESSL_ALL
         @ce_curl curl_easy_setopt CURLOPT_SSL_VERIFYHOST Int64(2)
         @ce_curl curl_easy_setopt CURLOPT_FTPSSLAUTH CURLFTPAUTH_SSL

--- a/src/FTPC.jl
+++ b/src/FTPC.jl
@@ -229,7 +229,7 @@ function setup_easy_handle(options::RequestOptions)
     @ce_curl curl_easy_setopt CURLOPT_URL ctxt.url
     # @ce_curl curl_easy_setopt CURLOPT_VERBOSE Int64(1)
 
-    if options.ssl || parse(Bool, get(ENV, "FTPS", "false"))
+    if options.ssl || parse(Bool, get(ENV, "FTPES", "false"))
         @ce_curl curl_easy_setopt CURLOPT_USE_SSL CURLUSESSL_ALL
         @ce_curl curl_easy_setopt CURLOPT_SSL_VERIFYHOST Int64(2)
         @ce_curl curl_easy_setopt CURLOPT_FTPSSLAUTH CURLFTPAUTH_SSL

--- a/test/ssl.jl
+++ b/test/ssl.jl
@@ -107,9 +107,9 @@ end
     ssl_tests(true, true)
     ssl_tests(true, false)
 
-    ENV["FTPS"] = true
-
     # Environment variable overrides specifying ssl=false
-    ssl_tests(false, true)
-    ssl_tests(false, false)
+    withenv("FTPS" => true) do
+        ssl_tests(false, true)
+        ssl_tests(false, false)
+    end
 end

--- a/test/ssl.jl
+++ b/test/ssl.jl
@@ -1,4 +1,4 @@
-function ssl_tests(implicit::Bool = true)
+function ssl_tests(ssl::Bool = true, implicit::Bool = true)
     mode = implicit ? :implicit : :explicit
 
     setup_server()
@@ -10,7 +10,7 @@ function ssl_tests(implicit::Bool = true)
         :port => port(server),
         :username => username(server),
         :password => password(server),
-        :ssl => true,
+        :ssl => ssl,
         :implicit => implicit,
         :verify_peer => false,
     )
@@ -104,6 +104,12 @@ function test_cmd(ctxt::ConnContext)
 end
 
 @testset "ssl" begin
-    ssl_tests(true)
-    ssl_tests(false)
+    ssl_tests(true, true)
+    ssl_tests(true, false)
+
+    ENV["FTPS"] = true
+
+    # Environment variable overrides specifying ssl=false
+    ssl_tests(false, true)
+    ssl_tests(false, false)
 end

--- a/test/ssl.jl
+++ b/test/ssl.jl
@@ -108,7 +108,7 @@ end
     ssl_tests(true, false)
 
     # Environment variable overrides specifying ssl=false
-    withenv("FTPS" => true) do
+    withenv("FTPES" => true) do
         ssl_tests(false, true)
         ssl_tests(false, false)
     end


### PR DESCRIPTION
Closes #64 

Did not find a common consensus on what such an environment variable should be called. ~Decided to go with `FTPS` as the simplest form denoting that FTP with SSL/TLS is being used, but I can change it easily.~ Updated to use `FTPES` to specify explicit SSL

Libcurl uses `CURLOPT_USE_SSL` as an option: https://curl.haxx.se/libcurl/c/CURLOPT_USE_SSL.html
Internally we use `FTP_SSL` so this would require the least amount of changes to other code.

Other options found:
`FTPS` is used here:  http://proftpd.org/docs/directives/linked/config_ref_TLSOptions.html
`FTP_USESSL` is used here:  https://support.hpe.com/hpsc/doc/public/display?docId=c03017718
`SAS_FTP_AUTHTLS` is used for SAS
