### PR TITLE
Update LibCURL to v0.4.1 and re-enable 32-bit windows

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
 julia 0.6
-LibCURL 0.3.2
+LibCURL 0.4.1
 URIParser
 Compat 0.62

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
     - julia_version: nightly
 
 platform:
-  # - x86 # 32-bit  # Limited by restriction on LibCURLBuilder: https://github.com/JuliaWeb/LibCURLBuilder/issues/6 
+  - x86 # 32-bit
   - x64 # 64-bit
 
 matrix:


### PR DESCRIPTION
Closes https://github.com/invenia/FTPClient.jl/issues/41

I temporarily ran the appveyor tests for this branch. Successful run here: https://ci.appveyor.com/project/invenia/ftpclient-jl/build/1.0.172