### PR TITLE
Remove ssl/url keyword deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,207 +1,95 @@
 FTPClient.jl
 ============
 
-Provides FTP client functionality based on [libcurl](https://github.com/JuliaWeb/LibCURL.jl).
-
 [![Build Status](https://travis-ci.org/invenia/FTPClient.jl.svg?branch=master)](https://travis-ci.org/invenia/FTPClient.jl)
 [![Build status](https://ci.appveyor.com/api/projects/status/ko8ama8fh0fgyjvq/branch/master?svg=true)](https://ci.appveyor.com/project/invenia/ftpclient-jl/branch/master)
 [![codecov.io](http://codecov.io/github/invenia/FTPClient.jl/coverage.svg)](http://codecov.io/github/invenia/FTPClient.jl)
 
-### Usage
-
-#### FTPC functions
-
-Note `ftp_init()` and  `ftp_cleanup()` need to be used once per session.
-
-Functions for non-persistent connection:
-
-```julia
-ftp_get(options::RequestOptions, file_name::AbstractString, save_path::AbstractString)
-ftp_put(options::RequestOptions, file_name::AbstractString, file::IO)
-ftp_command(options::RequestOptions, cmd::AbstractString)
-```
-
-These functions all establish a connection, perform the desired operation then close the
-connection and return a `Response` object. Any data retrieved from server is in
-`Response.body`:
-
-```julia
-mutable struct Response
-    body::IO
-    headers::Vector{AbstractString}
-    code::Int
-    total_time::FloatingPoint
-    bytes_recd::Int
-end
-```
-
-Functions for persistent connections:
-
-```julia
-ftp_connect(options::RequestOptions)
-ftp_get(ctxt::ConnContext, file_name::AbstractString, save_path::AbstractString)
-ftp_put(ctxt::ConnContext, file_name::AbstractString, file::IO)
-ftp_command(ctxt::ConnContext, cmd::AbstractString)
-ftp_close_connection(ctxt::ConnContext)
-```
-
-These functions all return a `Response` object, except `ftp_close_connection`, which does
-not return anything. Any data retrieved from server is in `Response.body`.
-
-```julia
-mutable struct ConnContext
-    curl::Ptr{CURL}
-    url::AbstractString
-    options::RequestOptions
-end
-```
-
-- `url` is of the form "localhost" or "127.0.0.1"
-- `cmd` is of the form "PWD" or "CWD Documents/", and must be a valid FTP command
-- `file_name` is both the name of the file that will be retrieved/uploaded and the name it will be saved as
-- `options` is a `RequestOptions` object
-
-```julia
-mutable struct RequestOptions
-    implicit::Bool
-    ssl::Bool
-    verify_peer::Bool
-    active_mode::Bool
-    username::AbstractString
-    password::AbstractString
-    url::AbstractString
-    hostname::AbstractString
-end
-```
-
-- `implicit`: use implicit security, default is false
-- `ssl`: use FTPS or FTPES (if implicit is set to false), default is false
-- `verify_peer`: verify authenticity of peer's certificate, default is true
-- `active_mode`: use active mode to establish data connection, default is false
-
-
-#### FTPObject functions
-
-```julia
-FTP(;hostname="", implicit=false, ssl=false, verify_peer=true, active_mode=false, username="", password="")
-close(ftp::FTP)
-download(ftp::FTP, file_name::AbstractString, save_path::AbstractString="")
-upload(ftp::FTP, local_name::AbstractString)
-upload(ftp::FTP, local_name::AbstractString, remote_name::AbstractString)
-upload(ftp::FTP, local_file::IO, remote_name::AbstractString)
-readdir(ftp::FTP)
-cd(ftp::FTP, dir::AbstractString)
-pwd(ftp::FTP)
-rm(ftp::FTP, file_name::AbstractString)
-rmdir(ftp::FTP, dir_name::AbstractString)
-mkdir(ftp::FTP, dir::AbstractString)
-mv(ftp::FTP, file_name::AbstractString, new_name::AbstractString)
-```
+A Julia FTP client using [LibCURL](https://github.com/JuliaWeb/LibCURL.jl) supporting FTP and FTP over SSL.
 
 ### Examples
 
-Using non-persistent connection and FTPS with implicit security:
+Depending on the settings of the FTP server you are connecting to you may need to deal with
+various security settings.
+
+- FTP with no Transport Layer Security (FTP). Typically uses port 21/TCP.
+
+    ```julia
+    julia> ftp = FTP(hostname="example.com", username="user", password="1234")
+    URL:       ftp://user:*****@example.com/
+    Transfer:  passive mode
+    Security:  none
+
+    julia> ftp = FTP("ftp://user:1234@example.com")
+    URL:       ftp://user:*****@example.com/
+    Transfer:  passive mode
+    Security:  none
+    ```
+
+- FTP with implicit security (FTPS). Typically uses port 990/TCP.
+
+    ```julia
+    julia> ftp = FTP(hostname="example.com", username="user", password="1234", ssl=true, implicit=true)
+    URL:       ftps://user:*****@example.com/
+    Transfer:  passive mode
+    Security:  implicit
+
+    julia> ftp = FTP("ftps://user:1234@example.com")
+    URL:       ftps://user:*****@example.com/
+    Transfer:  passive mode
+    Security:  implicit
+    ```
+
+- FTP with explicit security (FTPES). Typically uses port 21/TCP.
+
+    ```julia
+    julia> ftp = FTP(hostname="example.com", username="user", password="1234", ssl=true, implicit=false)
+    URL:       ftpes://user:*****@example.com/
+    Transfer:  passive mode
+    Security:  explicit
+
+    julia> ftp = FTP("ftpes://user:1234@example.com")
+    URL:       ftpes://user:*****@example.com/
+    Transfer:  passive mode
+    Security:  explicit
+    ```
+
+Once you've created your `FTP` instance you can use many of the [filesystem](https://docs.julialang.org/en/v1/base/file/)
+functions that Julia provides. A quick example showing some of the functions available:
 
 ```julia
-using FTPClient
+julia> cd(ftp, "Documents/School")
 
-ftp_init()
-options = RequestOptions(ssl=true, implicit=true, username="user1", password="1234", hostname="localhost")
+julia> pwd(ftp)
+"/Documents/School"
 
-resp = ftp_get(options, "download_file.txt")
-io_buffer = resp.body
+julia> readdir(ftp)
+1-element Array{String,1}:
+ "Assignment1.txt"
+ "Assignment2.txt"
 
-resp = ftp_get(options, "download_file.txt", "Documents/downloaded_file.txt")
-io_stream = resp.body
+julia> io = download(ftp, "Assignment1.txt");  # Download as IO stream
 
-file = open("upload_file.txt")
-resp = ftp_put(options, "upload_file.txt", file)
-close(file)
+julia> download(ftp, "Assignment2.txt", "./A2/Assignment2.txt");  # Save file to a specified path
 
-resp = ftp_command(options, "LIST")
-dir = resp.body
+julia> upload(ftp, "Assignment3.txt")  # Upload local file "Assignment3.txt" to FTP server
 
-ftp_cleanup()
+julia> open("Assignment3.txt") do fp
+           upload(ftp, fp, "Assignment3-copy.txt")  # Upload IO content as file "Assignment3-copy.txt" on FTP server
+       end
+
+julia> mv(ftp, "Assignment3-copy.txt", "Assignment3-dup.txt")
+
+julia> rm(ftp, "Assignment3-dup.txt")
+
+julia> mkdir(ftp, "tmp")
+
+julia> rmdir(ftp, "tmp")
+
+julia> close(ftp)
 ```
 
-Using persistent connection and FTPES with explicit security:
-
-```julia
-using FTPClient
-
-ftp_init()
-options = RequestOptions(ssl=true, username="user2", password="5678", url="localhost")
-
-ctxt = ftp_connect(options)
-
-resp = ftp_get(ctxt, "download_file.txt")
-io_buffer = resp.body
-
-resp = ftp_get(ctxt, "download_file.txt", "Documents/downloaded_file.txt")
-io_stream = resp.body
-
-resp = ftp_command(ctxt, "CWD Documents/")
-
-file = open("upload_file.txt")
-resp = ftp_put(ctxt, "upload_file.txt", file)
-close(file)
-
-ftp_close_connection(ctxt)
-
-ftp_cleanup()
-```
-
-Using the FTP object with a persistent connection and FTPS with implicit security:
-
-```julia
-ftp_init()
-ftp = FTP(hostname="localhost", implicit=true, ssl=true, username="user3", password="2468" )
-
-dir_list = readdir(ftp)
-cd(ftp, "Documents/School")
-pwd(ftp)
-
-# download file contents to buffer
-buff = download(ftp, "Assignment1.txt")
-
-# download and save file to specified path
-file = download(ftp, "Assignment2.txt", "./A2/Assignment2.txt")
-
-# upload file upload_file_name
-upload(ftp, upload_file_name)
-
-# upload file upload_file_name and change name to "new_name"
-upload(ftp, upload_file_name, "new_name")
-
-# upload contents of buffer and save to file
-buff = IOBuffer("Buffer to upload.")
-upload(ftp, buff, "upload_buffer.txt")
-
-# upload local file to server
-upload(ftp, file, "upload_file.txt")
-
-mv(ftp, "upload_file.txt", "Assignment3.txt")
-
-rm(ftp, "upload_buffer.txt")
-
-mkdir(ftp, "TEMP_DIR")
-rmdir(ftp, "TEMP_DIR")
-
-close(ftp)
-ftp_cleanup()
-```
-
-### Running Tests
-
-`julia --color=yes test/runtests.jl <use_ssl> <use_implicit> <username> <password>`
-
-### Code Coverage
-
-There are parts of the code that are not executed when running the basic test. The server is not yet equipped
-to check for error situations on command.
-
-
-## Troubleshoot
+## FAQ
 
 ### Downloaded files are unusable
 
@@ -209,10 +97,6 @@ Try downloading file in both binary and ASCII mode to see if one of the files is
 
 ### Linux and Travis CI
 
-Travis CI currently [does not reliably support FTP connections on sudo-enabled
-Linux](https://blog.travis-ci.com/2018-07-23-the-tale-of-ftp-at-travis-ci). This will
-usually manifest itself as a `Connection Timeout` error. Disable `sudo` for a workaround.
-
-### Other issues
-
-Please add any other problem or bugs to the issues page.
+Travis CI currently [does not reliably support FTP connections on sudo-enabled Linux]https://blog.travis-ci.com/2018-07-23-the-tale-of-ftp-at-travis-ci).
+This will usually manifest itself as a `Connection Timeout` error. Disable `sudo` for a
+workaround.

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -44,17 +44,9 @@ function FTP(;
     verify_peer::Bool=true,
     active_mode::Bool=false,
     verbose::Union{Bool,IOStream}=false,
-    url::AbstractString="",  # TODO: deprecate when we support this functionality elsewhere
 )
-    if !isempty(url)
-        Base.depwarn(string(
-            "Using `FTP` with the `url` keyword is deprecated; ",
-            "use `FTP(url, ...)` instead",
-        ), :FTP)
-    end
-
     options = RequestOptions(
-        username=username, password=password, hostname=hostname, port=port, url=url,
+        username=username, password=password, hostname=hostname, port=port,
         ssl=ssl, implicit=implicit, verify_peer=verify_peer, active_mode=active_mode,
     )
 

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -67,7 +67,6 @@ end
 Connect to an FTP server using the information specified in the URI.
 
 # Keywords
-- `ssl::Bool=false`: use a secure FTP connection.
 - `verify_peer::Bool=true`: verify the authenticity of the peer's certificate.
 - `active_mode::Bool=false`: use active mode to establish data connection.
 
@@ -85,18 +84,7 @@ function FTP(
     verify_peer::Bool=true,
     active_mode::Bool=false,
     verbose::Union{Bool,IOStream}=false,
-    ssl::Union{Nothing, Bool}=nothing,
 )
-    if ssl !== nothing
-        Base.depwarn(
-            "`FTP` keyword `ssl` has been depprecated, change the URL " *
-            "protocol to \"ftp://\", \"ftps://\", or \"ftpes://\" to respectively " *
-            "indicate no security, implicit security, or explicit security.",
-            :FTP
-        )
-        url = ssl ? replace(url, "ftp://" => "ftpes://") : url
-    end
-
     options = RequestOptions(url; verify_peer=verify_peer, active_mode=active_mode)
     FTP(options; verbose=verbose)
 end

--- a/src/request_options.jl
+++ b/src/request_options.jl
@@ -56,18 +56,7 @@ function RequestOptions(
     url::AbstractString;
     verify_peer::Bool=true,
     active_mode::Bool=false,
-    ssl::Union{Nothing, Bool}=nothing,
 )
-    if ssl !== nothing
-         Base.depwarn(
-            "`RequestOptions` keyword `ssl` has been depprecated, change the URL " *
-            "protocol to \"ftp://\", \"ftps://\", or \"ftpes://\" to respectively " *
-            "indicate no security, implicit security, or explicit security.",
-            :RequestOptions
-        )
-        url = ssl ? replace(url, "ftp://" => "ftpes://") : url
-    end
-
     uri = URI(url)
 
     if !(uri.scheme in ("ftps", "ftp", "ftpes"))

--- a/src/request_options.jl
+++ b/src/request_options.jl
@@ -30,7 +30,6 @@ function RequestOptions(;
     implicit::Bool=false,
     verify_peer::Bool=true,
     active_mode::Bool=false,
-    url::AbstractString="",
 )
     userinfo = if !isempty(password)
         username * ":" * password
@@ -38,16 +37,8 @@ function RequestOptions(;
         username
     end
 
-    uri = if isempty(url)
-        scheme = ssl ? (implicit ? "ftps" : "ftpes") : "ftp"
-        URI(scheme, hostname, port, "", "", "", userinfo)
-    else
-        Base.depwarn(string(
-            "Using `RequestOptions` with the `url` keyword is deprecated; ",
-            "use `RequestOptions(url, ...)` instead",
-        ), :RequestOptions)
-        URI(URI(url); userinfo=userinfo)
-    end
+    scheme = ssl ? (implicit ? "ftps" : "ftpes") : "ftp"
+    uri = URI(scheme, hostname, port, "", "", "", userinfo)
 
     RequestOptions(uri, ssl, verify_peer, active_mode)
 end


### PR DESCRIPTION
- `ssl` deprecation added in v0.5.0: https://github.com/invenia/FTPClient.jl/pull/67
- `url` deprecation added in v0.4.0: #63