### PR TITLE
Lazy FTP connections

### DIFF
--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -2,20 +2,19 @@
 const complete_transfer_code = 226
 
 
-struct FTP
+mutable struct FTP
     ctxt::ConnContext
+
+    function FTP(ctxt::ConnContext)
+        ftp = new(ctxt)
+        @compat finalizer(close, ftp)  # 0.7.0-DEV.2562
+        return ftp
+    end
 end
 
 function FTP(options::RequestOptions; verbose::Union{Bool,IOStream}=false)
-    try
-        ctxt, resp = ftp_connect(options; verbose=verbose)
-        FTP(ctxt)
-    catch err
-        if isa(err, FTPClientError)
-            err.msg = "Failed to connect."
-        end
-        rethrow()
-    end
+    ctxt = setup_easy_handle(options; verbose=verbose)
+    return FTP(ctxt)
 end
 
 """

--- a/test/ftp_object.jl
+++ b/test/ftp_object.jl
@@ -424,7 +424,7 @@ end
         ftp_init()
         try
             func(io)
-            close(io)
+            flush(io)
             return filesize(temp_file_path)
         finally
             close(io)


### PR DESCRIPTION
Only connect with the FTP server upon the first request which requires remote access. This allows users to create instances of `FTP` objects without having to connect to the server itself.