### PR TITLE
Make upload more consistent, remove retrys in upload.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ julia> close(ftp)
 If you want to upload a file but retry on failures you can do the following:
 
 ```julia
-julia> ftp_retry = retry(delays=fill(5, 4)) do
+julia> ftp_retry = retry(delays=fill(5.0, 3)) do
            upload(ftp, "Assignment3.txt", ".")
        end
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ julia> io = download(ftp, "Assignment1.txt");  # Download as IO stream
 
 julia> download(ftp, "Assignment2.txt", "./A2/Assignment2.txt");  # Save file to a specified path
 
-julia> upload(ftp, "Assignment3.txt")  # Upload local file "Assignment3.txt" to FTP server
+julia> upload(ftp, "Assignment3.txt", ".")  # Upload local file "Assignment3.txt" to FTP server home directory
 
 julia> open("Assignment3.txt") do fp
            upload(ftp, fp, "Assignment3-copy.txt")  # Upload IO content as file "Assignment3-copy.txt" on FTP server
@@ -87,6 +87,14 @@ julia> mkdir(ftp, "tmp")
 julia> rmdir(ftp, "tmp")
 
 julia> close(ftp)
+```
+
+If you want to upload a file but retry on failures you can do the following:
+
+```julia
+julia> retry(delays=fill(5, 4)) do
+           upload(ftp, "Assignment3.txt", ".")
+       end
 ```
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -92,9 +92,11 @@ julia> close(ftp)
 If you want to upload a file but retry on failures you can do the following:
 
 ```julia
-julia> retry(delays=fill(5, 4)) do
+julia> ftp_retry = retry(delays=fill(5, 4)) do
            upload(ftp, "Assignment3.txt", ".")
        end
+
+julia> ftp_retry()
 ```
 
 ## FAQ

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -170,7 +170,7 @@ function upload(
         resp = ftp_put(ftp_options, remote_path, local_path_io; mode=mode, verbose=verbose)
     catch e
         if isa(e, FTPClientError)
-            err = "Faild to upload $remote_path"
+            err = "Failed to upload $remote_path"
             e.msg = !isempty(e.msg) ? "$(e.msg) - $err" : err
         end
         rethrow()
@@ -193,7 +193,7 @@ Uploads the file specified in "local_path" to the file or directory specifies in
 "remote_path".
 
 If "remote_path" is a path to a file, then the file will be uploaded to the FTP
-using the full file path name. If "remote_path" is a path to a directory (which means
+using the provided path. If "remote_path" is a path to a directory (which means
 it ends in "/", ".", or ".."), then the file will be uploaded to the specified directory
 but with the "local_path" basename as the file name.
 

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -137,7 +137,7 @@ end
         ftp_options=ftp.ctxt,
         mode::FTP_MODE=binary_mode,
         verbose=nothing
-) -> (Bool, FTPResponse)
+) -> Response
 
 Upload IO object "local_path_io" to the FTP server and save as "remote_path".
 
@@ -152,7 +152,6 @@ Upload IO object "local_path_io" to the FTP server and save as "remote_path".
 `verbose=nothing`: Set the verbosity
 
 # Returns
-`Bool`: Returns a boolean with true if the file was successfully transfered, else false.
 `FTPResponse`: Returns the ftp response object, else nothing
 """
 function upload(
@@ -165,20 +164,17 @@ function upload(
 )
     _dep_verbose_kw(verbose, typeof(ftp), :upload)
 
-    # Whether or not the current IO was successfully delivered to the FTP
-    success = false
     resp = nothing
 
     try
         resp = ftp_put(ftp_options, remote_path, local_path_io; mode=mode, verbose=verbose)
-        success = resp.code == complete_transfer_code
     catch e
         if isa(e, FTPClientError)
             e.msg = "Failed to upload $remote_path"
         end
         rethrow()
     end
-    return success, resp
+    return resp
 end
 
 
@@ -190,7 +186,7 @@ end
         ftp_options=ftp.ctxt,
         mode::FTP_MODE=binary_mode,
         verbose=nothing,
-    ) -> (Bool, FTPResponse)
+    ) -> Response
 
 Uploads the file specified in "local_path" to the file or directory specifies in
 "remote_path".
@@ -211,7 +207,6 @@ it ends in "/"), then the file will be uploaded to the specified directory but w
 `verbose=nothing`: Set the verbosity
 
 # Returns
-`Bool`: Returns a boolean with true if the file was successfully transfered, else false.
 `FTPResponse`: Returns the ftp response object, else nothing
 """
 function upload(
@@ -246,45 +241,6 @@ function upload(
             ftp_options=ftp_options, mode=mode, verbose=verbose
         )
     end
-end
-
-"""
-    upload(
-        ftp::FTP,
-        local_path::AbstractString;
-        ftp_options=ftp.ctxt,
-        mode::FTP_MODE=binary_mode,
-        verbose=nothing,
-    ) -> (Bool, FTPResponse)
-
-Uploads the file specified in "local_path" to the FTP as "local_path"
-
-# Arguments
-`ftp::FTP`: The FTP to deliver to. See FTPClient.FTP for details.
-`local_path::AbstractString`: The file path to the file we want to deliver.
-
-# Keywords
-`ftp_options=ftp.ctxt`: FTP Options
-`mode::FTP_MODE=binary_mode`: Set the ftp mode.
-`verbose=nothing`: Set the verbosity
-
-# Returns
-`Bool`: Returns a boolean with true if the file was successfully transfered, else false.
-`FTPResponse`: Returns the ftp response object, else nothing
-"""
-function upload(
-    ftp::FTP,
-    local_path::AbstractString;
-    ftp_options=ftp.ctxt,
-    mode::FTP_MODE=binary_mode,
-    verbose=nothing
-)
-    _dep_verbose_kw(verbose, typeof(ftp), :upload)
-
-    return upload(
-        ftp, local_path, local_path;
-        ftp_options=ftp_options, mode=mode, verbose=verbose
-    )
 end
 
 """

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -142,17 +142,17 @@ end
 Upload IO object "local_path_io" to the FTP server and save as "remote_path".
 
 # Arguments
-`ftp::FTP`: The FTP to deliver to. See FTPClient.FTP for details.
-`local_path_io::IO`: The IO object that we want to deliver.
-`remote_path::AbstractString`: The path that we want to deliver to.
+- `ftp::FTP`: The FTP to deliver to. See FTPClient.FTP for details.
+- `local_path_io::IO`: The IO object that we want to deliver.
+- `remote_path::AbstractString`: The path that we want to deliver to.
 
 # Keywords
-`ftp_options=ftp.ctxt`: FTP Options
-`mode::FTP_MODE=binary_mode`: Set the ftp mode.
-`verbose=nothing`: Set the verbosity
+- `ftp_options=ftp.ctxt`: FTP Options
+- `mode::FTP_MODE=binary_mode`: Set the ftp mode.
+- `verbose=nothing`: Set the verbosity
 
 # Returns
-`FTPResponse`: Returns the ftp response object, else nothing
+- `FTPResponse`: Returns the ftp response object
 """
 function upload(
     ftp::FTP,
@@ -197,17 +197,17 @@ it ends in "/"), then the file will be uploaded to the specified directory but w
 "local_path" basename as the file name.
 
 # Arguments
-`ftp::FTP`: The FTP to deliver to. See FTPClient.FTP for details.
-`local_path::AbstractString`: The file path to the file we want to deliver.
-`remote_path::AbstractString`: The file/dir path that we want to deliver to.
+- `ftp::FTP`: The FTP to deliver to. See FTPClient.FTP for details.
+- `local_path::AbstractString`: The file path to the file we want to deliver.
+- `remote_path::AbstractString`: The file/dir path that we want to deliver to.
 
 # Keywords
-`ftp_options=ftp.ctxt`: FTP Options
-`mode::FTP_MODE=binary_mode`: Set the ftp mode.
-`verbose=nothing`: Set the verbosity
+- `ftp_options=ftp.ctxt`: FTP Options
+- `mode::FTP_MODE=binary_mode`: Set the ftp mode.
+- `verbose=nothing`: Set the verbosity
 
 # Returns
-`FTPResponse`: Returns the ftp response object, else nothing
+- `FTPResponse`: Returns the ftp response object
 """
 function upload(
     ftp::FTP,

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -224,7 +224,7 @@ function upload(
         # If the remote path was just a directory, then the full remote path should be
         # that directory plus the basename of the local_path
         server_location = joinpath(dirname(remote_path), basename(local_path))
-    elseif remote_path[end] == '.'
+    elseif basename(remote_path) == "."
         # Handle the special case where remote_path ends with '.'
         # Since the dirname/basename strategy doesn't work in this specific case, we just
         # handle it here.

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -170,7 +170,8 @@ function upload(
         resp = ftp_put(ftp_options, remote_path, local_path_io; mode=mode, verbose=verbose)
     catch e
         if isa(e, FTPClientError)
-            e.msg = "Failed to upload $remote_path"
+            err = "Faild to upload $remote_path"
+            e.msg = !isempty(e.msg) ? "$(e.msg) - $err" : err
         end
         rethrow()
     end

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -152,7 +152,7 @@ Upload IO object "local_path_io" to the FTP server and save as "remote_path".
 - `verbose=nothing`: Set the verbosity
 
 # Returns
-- `FTPResponse`: Returns the ftp response object
+`FTPResponse`: Returns the ftp response object
 """
 function upload(
     ftp::FTP,
@@ -207,7 +207,7 @@ it ends in "/"), then the file will be uploaded to the specified directory but w
 - `verbose=nothing`: Set the verbosity
 
 # Returns
-- `FTPResponse`: Returns the ftp response object
+`FTPResponse`: Returns the ftp response object
 """
 function upload(
     ftp::FTP,

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -224,11 +224,11 @@ function upload(
         # If the remote path was just a directory, then the full remote path should be
         # that directory plus the basename of the local_path
         server_location = joinpath(dirname(remote_path), basename(local_path))
-    elseif remote_path == "."
-        # Handle the special case where remote_path is "."
+    elseif remote_path[end] == '.'
+        # Handle the special case where remote_path ends with '.'
         # Since the dirname/basename strategy doesn't work in this specific case, we just
         # handle it here.
-        server_location = joinpath(".", basename(local_path))
+        server_location = joinpath(remote_path, basename(local_path))
     else
         # If the remote path is a full file path, then just use that
         server_location = remote_path

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -26,10 +26,15 @@ function upload(
     depwarn(
         string(
             "Uploading multiple files to an ftp_dir with a retry callback is deprecated. ",
-            "Use retry in a file path loop in the future:\n",
-            "for single_file in file_paths\n    ",
-            "retry(delays=fill(5, 4)) do\n        ",
-            "upload(ftp, local_path, remote_path; kwargs... )\n    end\nend",
+            """
+            Use retry in a file path loop in the future:
+            for single_file in file_paths
+                ftp_retry = retry(delays=fill(5, 4)) do
+                    upload(ftp, local_path, remote_path; kwargs... )
+                end
+                ftp_retry()
+            end
+            """,
         ),
         :upload
     )

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -26,9 +26,10 @@ function upload(
     depwarn(
         string(
             "Uploading multiple files to an ftp_dir with a retry callback is deprecated. ",
-            "Use retry(upload, delays=fill(5, 4))",
-            "(ftp, local_path, remote_path; kwargs... ) ",
-            "in a loop of file_paths in the future."
+            "Use retry in a file path loop in the future:\n",
+            "for single_file in file_paths\n    ",
+            "retry(delays=fill(5, 4)) do\n        ",
+            "upload(ftp, local_path, remote_path; kwargs... )\n    end\nend",
         ),
         :upload
     )

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -29,7 +29,7 @@ function upload(
             """
             Use retry in a file path loop in the future:
             for single_file in file_paths
-                ftp_retry = retry(delays=fill(5, 4)) do
+                ftp_retry = retry(delays=fill(5.0, 3)) do
                     upload(ftp, local_path, remote_path; kwargs... )
                 end
                 ftp_retry()

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,9 +1,79 @@
+using Base: @deprecate, depwarn
+
 function _dep_verbose_kw(verbose, preferred::Type, func::Symbol)
     if verbose !== nothing
-        Base.depwarn(
+        depwarn(
             "The `verbose` keyword is deprecated and now needs to be supplied " *
             "during the initialization of `$(nameof(preferred))`.",
             func,
         )
     end
+end
+
+@deprecate(
+    upload(ftp::FTP, local_name::AbstractString; kwargs...),
+    upload(ftp, local_name, local_name; kwargs...)
+)
+
+function upload(
+    ftp::FTP,
+    local_file_paths::Vector{<:AbstractString},
+    ftp_dir::AbstractString;
+    retry_callback::Function=(count, options) -> (count < 4, options),
+    retry_wait_seconds::Integer=5,
+    verbose=nothing,
+)
+    depwarn(
+        string(
+            "Uploading multiple files to an ftp_dir with a retry callback is deprecated. ",
+            "Use retry(upload, delays=fill(5, 4))",
+            "(ftp, local_path, remote_path; kwargs... ) ",
+            "in a loop of file_paths in the future."
+        ),
+        :upload
+    )
+    _dep_verbose_kw(verbose, typeof(ftp), :upload)
+
+    successful_delivery = Bool[]
+    ftp_options = ftp.ctxt
+
+    for single_file in local_file_paths
+        # The location we are going to drop the file in the FTP server
+        server_location = joinpath(ftp_dir, basename(single_file))
+        open(single_file) do single_file_io
+            # Whether or not the current file was successfully delivered to the FTP
+            success = false
+            # Count the number of time we have tried to upload the file
+            attempts = 1
+            # The loops should break after an appropriate amount of retries.
+            # This way of doing retries makes testing easier.
+            # Defaults to 4 attempts, waiting 5 seconds between each retry.
+            while true
+                try
+                    resp = upload(
+                        ftp, single_file_io, server_location;
+                        ftp_options=ftp_options, verbose=verbose
+                    )
+                    success = resp.code == complete_transfer_code
+
+                    if success
+                        break
+                    end
+                catch e
+                    @warn(e)
+                end
+                sleep(retry_wait_seconds)
+                # It returns ftp_options for testing purposes, where the ftp_server
+                # starts not existing then comes into existance during retries.
+                do_retry, ftp_options = retry_callback(attempts, ftp_options)
+                if !do_retry
+                    break
+                end
+                attempts += 1
+            end
+            push!(successful_delivery, success)
+        end
+    end
+
+    return successful_delivery
 end

--- a/test/ftp_object.jl
+++ b/test/ftp_object.jl
@@ -397,55 +397,6 @@ end
     )(ftp, upload_file, "/")
 end
 
-@testset "deprecated" begin
-    # test deprecated upload functions
-    @testset "upload" begin
-        # Test the singular local file upload
-        ftp = FTP(; opts...)
-        server_file = joinpath(HOMEDIR, upload_file)
-        @test !isfile(server_file)
-        resp = copy_and_wait(server_file) do
-            @test_deprecated upload(ftp, upload_file)
-        end
-
-        @test isfile(server_file)
-        @test read(upload_file, String) == read(server_file, String)
-        no_unexpected_changes(ftp)
-        cleanup_file(server_file)
-        close(ftp)
-
-        # Test the multiple file upload with retry
-        ftp = FTP(; opts...)
-        upload_list = [upload_file, upload_file_2, upload_file_3, upload_file_4]
-
-        server_file = joinpath(HOMEDIR, "test_upload.txt")
-        @test !isfile(server_file)
-        server_file_2 = joinpath(HOMEDIR, "test_upload_2.txt")
-        @test !isfile(server_file_2)
-        server_file_3 = joinpath(HOMEDIR, "test_upload_3.txt")
-        @test !isfile(server_file_3)
-        server_file_4 = joinpath(HOMEDIR, "test_upload_4.txt")
-        @test !isfile(server_file_4)
-
-        server_list = [server_file, server_file_2, server_file_3, server_file_4]
-
-        resp = copy_and_wait(server_list...) do
-            @test_deprecated upload(ftp, upload_list, "/")
-        end
-
-        @test resp == [true, true, true, true]
-
-        for (ufile, sfile) in zip(upload_list, server_list)
-            @test isfile(sfile)
-            @test read(ufile, String) == read(sfile, String)
-        end
-
-        no_unexpected_changes(ftp)
-        map(cleanup_file, server_list)
-        close(ftp)
-    end
-end
-
 @testset "write" begin
     # check write to file
     ftp = FTP(; opts...)

--- a/test/ftp_object.jl
+++ b/test/ftp_object.jl
@@ -307,7 +307,7 @@ end
     # this strategy where the ftp client comes back up between trys.
     @test_throws FTPClientError retry(
         upload, delays=fill(0.1, 2)
-    )(ftp, joinpath(HOMEDIR, "test_upload.txt"), "/")
+    )(ftp, upload_file, "/")
 end
 
 @testset "write" begin

--- a/test/ftp_object.jl
+++ b/test/ftp_object.jl
@@ -108,8 +108,8 @@ end
     # check readdir
     ftp = FTP(; opts...)
     server_dir = readdir(ftp)
-    @test occursin("test_directory", string(server_dir))
-    @test occursin("test_download.txt", string(server_dir))
+    @test "test_directory" in server_dir
+    @test "test_download.txt" in server_dir
     no_unexpected_changes(ftp)
     close(ftp)
 end

--- a/test/ftp_object.jl
+++ b/test/ftp_object.jl
@@ -1,8 +1,6 @@
 mv_file = "test_mv.txt"
 tempfile(mv_file)
 
-global retry_server = nothing
-
 opts = (
     :hostname => hostname(server),
     :port => port(server),
@@ -35,10 +33,10 @@ function expected_output(active::Bool)
     close(ftp)
 end
 
-function copy_and_wait(f::Function, files...; timeout=30)
+function copy_and_wait(func::Function, files...; timeout=30)
     # Writing/uploading FTP files can have concurrency issues so we repeatedly
     # try and read the destination file until we have data.
-    resp = f()
+    resp = func()
 
     for f in files
         file_data = ""
@@ -55,25 +53,6 @@ function copy_and_wait(f::Function, files...; timeout=30)
     end
 
     return resp
-end
-
-# Function that will bring up the server after a few retries, and returns
-# connection details that over ride the previously defined wrong connection.
-# Used for testing upload with retries.
-function retry_test(count, options)
-
-    # Fail on the first attempt
-    if count == 1
-        return (true, options)
-    # Bring up the FTP and return connection options to it on the second attempt
-    # So the second attempt should succeed.
-    elseif count == 2
-        global retry_server = FTP(; opts...)
-        return (true, retry_server.ctxt)
-    else
-        # Try and prevent infinite loops with this, but should never be an issue.
-        return (false, options)
-    end
 end
 
 @testset "connection error" begin
@@ -319,76 +298,16 @@ end
     close(ftp)
 
     # Check upload with retry, single file
-    ftp = FTP(; opts...)
-    server_file= joinpath(HOMEDIR, "test_upload.txt")
-    @test !isfile(server_file)
-
-    resp = copy_and_wait(server_file) do
-        upload(ftp, [upload_file], "/")
-    end
-
-    @test resp == [true]
-    @test isfile(server_file)
-    @test read(upload_file, String) == read(server_file, String)
-
-    no_unexpected_changes(ftp)
-    cleanup_file(server_file)
-    close(ftp)
-
-    # Check upload with retry, multiple files
-    ftp = FTP(; opts...)
-    upload_list = [upload_file, upload_file_2, upload_file_3, upload_file_4]
-
-    server_file = joinpath(HOMEDIR, "test_upload.txt")
-    @test !isfile(server_file)
-    server_file_2 = joinpath(HOMEDIR, "test_upload_2.txt")
-    @test !isfile(server_file_2)
-    server_file_3 = joinpath(HOMEDIR, "test_upload_3.txt")
-    @test !isfile(server_file_3)
-    server_file_4 = joinpath(HOMEDIR, "test_upload_4.txt")
-    @test !isfile(server_file_4)
-
-    server_list = [server_file, server_file_2, server_file_3, server_file_4]
-
-    resp = copy_and_wait(server_list...) do
-        upload(ftp, upload_list, "/")
-    end
-
-    @test resp == [true, true, true, true]
-
-    for (ufile, sfile) in zip(upload_list, server_list)
-        @test isfile(sfile)
-        @test read(ufile, String) == read(sfile, String)
-    end
-
-    no_unexpected_changes(ftp)
-    map(cleanup_file, server_list)
-    close(ftp)
-
-    # Check upload with retry, multiple files, where it will fail the first time
     # Get the FTP object
     ftp = FTP(; opts...)
     # Close the FTP so we can't connect to it
     close(ftp)
 
-    # When this function is first called, ftp should not be functioning
-    # It should wait for 1 retry, then create a server and put the details in the
-    # retry_server variable, and use that to transfer the files.
-    resp = copy_and_wait(server_list...) do
-        upload(ftp, upload_list, "/", retry_callback=retry_test, retry_wait_seconds=1)
-    end
-
-    @test resp == [true, true, true, true]
-
-    for (ufile, sfile) in zip(upload_list, server_list)
-        @test isfile(sfile)
-        @test read(ufile, String) == read(sfile, String)
-    end
-
-    no_unexpected_changes(retry_server)
-    map(cleanup_file, server_list)
-
-    close(retry_server)
+    # This will run twice, and fail both times. I currently don't know a good way to test
+    # this strategy where the ftp client comes back up between trys.
+    @test_throws FTPClientError retry(
+        upload, delays=fill(0.1, 2)
+    )(ftp, joinpath(HOMEDIR, "test_upload.txt"), "/")
 end
 
 @testset "write" begin
@@ -639,26 +558,6 @@ end
                 captured_size() do io
                     ftp = FTP(; opts..., verbose=io)
                     upload(ftp, upload_file, "some name")
-                end
-            end
-
-            @test num_bytes > 0
-            @test isfile(server_file)
-            @test read(upload_file, String) == read(server_file, String)
-            no_unexpected_changes(ftp)
-            cleanup_file(server_file)
-            close(ftp)
-        end
-        @testset "upload with retry single file" begin
-            server_file= joinpath(HOMEDIR, "test_upload.txt")
-            @test !isfile(server_file)
-
-            local ftp
-            num_bytes = copy_and_wait(server_file) do
-                captured_size() do io
-                    ftp = FTP(; opts..., verbose=io)
-                    resp = upload(ftp, [upload_file], "/")
-                    @test resp == [true]
                 end
             end
 

--- a/test/ftp_object.jl
+++ b/test/ftp_object.jl
@@ -114,10 +114,9 @@ end
     tempfile(local_file)
     @test isfile(local_file)
 
-    success, resp = copy_and_wait(server_file) do
-        upload(ftp, local_file)
+    resp = copy_and_wait(server_file) do
+        upload(ftp, local_file, local_file)
     end
-    @test success
     @test isfile(server_file)
     @test read(local_file, String) == read(server_file, String)
 
@@ -273,10 +272,9 @@ end
     @test isfile(upload_file)
     @test !isfile(server_file)
 
-    success, resp = copy_and_wait(server_file) do
-        upload(ftp, upload_file)
+    resp = copy_and_wait(server_file) do
+        upload(ftp, upload_file, upload_file)
     end
-    @test success
     @test isfile(server_file)
     @test read(upload_file, String) == read(server_file, String)
 
@@ -289,10 +287,9 @@ end
     server_file= joinpath(HOMEDIR, "some name")
     @test !isfile(server_file)
 
-    success, resp = copy_and_wait(server_file) do
+    resp = copy_and_wait(server_file) do
         upload(ftp, upload_file, "some name")
     end
-    @test success
     @test isfile(server_file)
     @test read(upload_file, String) == read(server_file, String)
 
@@ -318,13 +315,12 @@ end
     ftp = FTP(; opts...)
     server_file= joinpath(HOMEDIR, "some other name")
     @test !isfile(server_file)
-    success, resp = copy_and_wait(server_file) do
+    resp = copy_and_wait(server_file) do
         open(upload_file) do fp
             upload(ftp, fp, "some other name")
         end
     end
 
-    @test success
     @test isfile(server_file)
     @test read(upload_file, String) == read(server_file, String)
     no_unexpected_changes(ftp)
@@ -398,7 +394,7 @@ end
         num_bytes = copy_and_wait(server_file) do
             captured_size() do io
                 ftp = FTP(; opts..., verbose=io)
-                upload(ftp, upload_file)
+                upload(ftp, upload_file, upload_file)
             end
         end
 
@@ -542,7 +538,7 @@ end
             num_bytes = copy_and_wait(server_file) do
                 captured_size() do io
                     ftp = FTP(; opts..., verbose=io)
-                    upload(ftp, upload_file)
+                    upload(ftp, upload_file, upload_file)
                 end
             end
 

--- a/test/ftp_object.jl
+++ b/test/ftp_object.jl
@@ -124,7 +124,44 @@ end
 end
 
 @testset "upload" begin
-    # check upload
+    # check upload "." dot path
+    ftp = FTP(; opts...)
+    local_file = upload_file
+    server_file = joinpath(HOMEDIR, local_file)
+    tempfile(local_file)
+    @test isfile(local_file)
+
+    resp = copy_and_wait(server_file) do
+        upload(ftp, local_file, ".")
+    end
+    @test isfile(server_file)
+    @test read(local_file, String) == read(server_file, String)
+
+    no_unexpected_changes(ftp)
+    close(ftp)
+    cleanup_file(server_file)
+
+    # check upload "/" slash path
+    ftp = FTP(; opts...)
+    local_file = upload_file
+    server_dir = joinpath(HOMEDIR, testdir)
+    mkdir(ftp, testdir)
+    server_file = joinpath(server_dir, local_file)
+    tempfile(local_file)
+    @test isfile(local_file)
+
+    resp = copy_and_wait(server_file) do
+        upload(ftp, local_file, "$testdir/")
+    end
+    @test isfile(server_file)
+    @test read(local_file, String) == read(server_file, String)
+
+    no_unexpected_changes(ftp)
+    close(ftp)
+    cleanup_file(server_file)
+    cleanup_dir(server_dir)
+
+    # check upload full remote path
     ftp = FTP(; opts...)
     local_file = upload_file
     server_file = joinpath(HOMEDIR, local_file)

--- a/test/ftp_object.jl
+++ b/test/ftp_object.jl
@@ -161,6 +161,28 @@ end
     cleanup_file(server_file)
     cleanup_dir(server_dir)
 
+    # Check dir + ".." dot path
+    testdir2 = "double_test"
+    ftp = FTP(; opts...)
+    local_file = upload_file
+    server_dir = joinpath(HOMEDIR, testdir)
+    mkdir(ftp, testdir)
+    mkdir(ftp, joinpath(testdir, testdir2))
+    server_file = joinpath(server_dir, local_file)
+    tempfile(local_file)
+
+    resp = copy_and_wait(server_file) do
+        upload(ftp, local_file, "$testdir/$testdir2/..")
+    end
+    @test isfile(server_file)
+    @test read(local_file, String) == read(server_file, String)
+
+    no_unexpected_changes(ftp)
+    close(ftp)
+    cleanup_file(server_file)
+    cleanup_dir(joinpath(server_dir, testdir2))
+    cleanup_dir(server_dir)
+
     # check upload "/" slash path
     ftp = FTP(; opts...)
     local_file = upload_file


### PR DESCRIPTION
Changes based on:
https://github.com/invenia/FTPClient.jl/issues/73
and comments from @omus 
"I personally think we should have a simple and consistent upload function (see: https://github.com/invenia/FTPClient.jl/issues/73) which contains no retries by default. We should then try out how easy/awkward it is for users to implement retries on their own using retry. If the interface is two difficult we can add the functionality as another function or something else."

This change makes the IO path (uploading an io object to a remote path) the penultimate upload function as it's the only one that does an ftp_put. All other upload functions eventually
call the IO version.
I have also removed the upload function that takes in an array of file paths as the user can handle iterating through files themselves. With this change the retry ability has also been removed as users could implement it themselves using retry. There is a test for this in the tests.
If we end up deciding that the retry function should still exist in this package, we can build it back up on top of the new upload functions.

Tests have been modified to remove retry and file path array specific tests.
Added a test using the julia retry function, but have yet to figure out a good way to test an FTP server coming back up between retrys.

Extra Notes:
I have also done a bit of name editing, such as using "local_path" rather than "local_name", as I think it makes more sense, but I am definitely open to suggestions on that one. 
I'm not really sure that passing ftp_options is necessary at all. I had that in there earlier for the old retry testing, but since I took the retry stuff out I don't think it's needed.

Edit: I suppose I should throw some deprecates in there too if we decide to remove some functions?