### PR TITLE
Avoid specifying CONDA_JL_VERSION for Appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,5 +1,4 @@
 environment:
-  CONDA_JL_VERSION: 2
   matrix:
     - julia_version: 1.0
     - julia_version: 1.1


### PR DESCRIPTION
As noted in [this comment](https://github.com/invenia/FTPClient.jl/pull/93#issuecomment-632760835) Appveyor Windows 32-bit was hanging. It is suspected that the use of Python 2 on Windows 32-bit may be the issue.