### PR TITLE
Remove deprecated __precompile__()

### DIFF
--- a/src/FTPClient.jl
+++ b/src/FTPClient.jl
@@ -1,5 +1,3 @@
-__precompile__()
-
 module FTPClient
 
 using URIParser: URI


### PR DESCRIPTION
Taken from: https://github.com/invenia/FTPClient.jl/pull/84