### PR TITLE
Support for FTPServer 0.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ LibCURL = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 URIParser = "30578b45-9adc-5946-b283-645ec420af67"
 
 [compat]
-FTPServer = "0.2.3"
+FTPServer = "0.3"
 LibCURL = "0.5.1, 0.6"
 URIParser = "0.4"
 julia = "0.7, 1.0"

--- a/test/non_ssl.jl
+++ b/test/non_ssl.jl
@@ -208,8 +208,10 @@ end
     Sys.iswindows() && (upload_bytes = b"FooBar\r\nFooBar")
 
     Sys.isunix() && (download_bytes = b"FooBar\r\nFooBar")
-    Sys.isunix() && (download_bytes_ascii = b"FooBar\nFooBar")
     Sys.iswindows() && (download_bytes = b"FooBar\nFooBar\x1a\x1a\x1a")
+
+    # Detect carriage return
+    cr(b::UInt8) = b == UInt8('\r')
 
     byte_upload_file = "test_upload_byte_file"
     byte_file = "test_byte_file"
@@ -222,8 +224,7 @@ end
     options = RequestOptions(; opts..., ssl=false, active_mode=false)
     resp = ftp_get(options, byte_file; mode=ascii_mode)
     bytes = read(resp.body)
-    Sys.isunix() && @test bytes != download_bytes
-    Sys.isunix() && @test bytes == download_bytes_ascii
+    Sys.isunix() && @test bytes == filter(!cr, download_bytes)
 
     # it is the same file when downloading in binary mode
     resp = ftp_get(options, byte_file)
@@ -234,8 +235,7 @@ end
     ctxt, resp = ftp_connect(options)
     resp = ftp_get(ctxt, byte_file, mode=ascii_mode)
     bytes = read(resp.body)
-    Sys.isunix() && @test bytes != download_bytes
-    Sys.isunix() && @test bytes == download_bytes_ascii
+    Sys.isunix() && @test bytes == filter(!cr, download_bytes)
     ftp_close_connection(ctxt)
 
     # it is the same file when downloading in binary mode
@@ -249,8 +249,7 @@ end
     ftp = FTP(; opts...)
     buff = download(ftp, byte_file, mode=ascii_mode)
     bytes = read(buff)
-    Sys.isunix() && @test bytes != download_bytes
-    Sys.isunix() && @test bytes == download_bytes_ascii
+    Sys.isunix() && @test bytes == filter(!cr, download_bytes)
     Base.close(ftp)
 
     # it is the same file when downloading in binary mode
@@ -264,15 +263,13 @@ end
     ftp = FTP(; opts...)
     buff = download(ftp, byte_file, mode=ascii_mode)
     bytes = read(buff)
-    Sys.isunix() && @test bytes != download_bytes
-    Sys.isunix() && @test bytes == download_bytes_ascii
+    Sys.isunix() && @test bytes == filter(!cr, download_bytes)
     buff = download(ftp, byte_file)
     bytes = read(buff)
     @test bytes == download_bytes
     buff = download(ftp, byte_file, mode=ascii_mode)
     bytes = read(buff)
-    Sys.isunix() && @test bytes != download_bytes
-    Sys.isunix() && @test bytes == download_bytes_ascii
+    Sys.isunix() && @test bytes == filter(!cr, download_bytes)
     Base.close(ftp)
 
     # upload

--- a/test/non_ssl.jl
+++ b/test/non_ssl.jl
@@ -208,7 +208,7 @@ end
     Sys.iswindows() && (upload_bytes = b"FooBar\r\nFooBar")
 
     Sys.isunix() && (download_bytes = b"FooBar\r\nFooBar")
-    Sys.isunix() && (download_bytes_ascii = b"FooBar\n\nFooBar")
+    Sys.isunix() && (download_bytes_ascii = b"FooBar\nFooBar")
     Sys.iswindows() && (download_bytes = b"FooBar\nFooBar\x1a\x1a\x1a")
 
     byte_upload_file = "test_upload_byte_file"

--- a/test/non_ssl.jl
+++ b/test/non_ssl.jl
@@ -230,7 +230,7 @@ end
     options = RequestOptions(; opts..., ssl=false, active_mode=false)
     resp = ftp_get(options, byte_file; mode=ascii_mode)
     bytes = read(resp.body)
-    Sys.isunix() && @test bytes == filter(!cr, download_bytes)
+    @test bytes == filter(!cr, download_bytes)
 
     # it is the same file when downloading in binary mode
     resp = ftp_get(options, byte_file)
@@ -241,7 +241,7 @@ end
     ctxt, resp = ftp_connect(options)
     resp = ftp_get(ctxt, byte_file, mode=ascii_mode)
     bytes = read(resp.body)
-    Sys.isunix() && @test bytes == filter(!cr, download_bytes)
+    @test bytes == filter(!cr, download_bytes)
     ftp_close_connection(ctxt)
 
     # it is the same file when downloading in binary mode
@@ -255,7 +255,7 @@ end
     ftp = FTP(; opts...)
     buff = download(ftp, byte_file, mode=ascii_mode)
     bytes = read(buff)
-    Sys.isunix() && @test bytes == filter(!cr, download_bytes)
+    @test bytes == filter(!cr, download_bytes)
     Base.close(ftp)
 
     # it is the same file when downloading in binary mode
@@ -269,13 +269,13 @@ end
     ftp = FTP(; opts...)
     buff = download(ftp, byte_file, mode=ascii_mode)
     bytes = read(buff)
-    Sys.isunix() && @test bytes == filter(!cr, download_bytes)
+    @test bytes == filter(!cr, download_bytes)
     buff = download(ftp, byte_file)
     bytes = read(buff)
     @test bytes == download_bytes
     buff = download(ftp, byte_file, mode=ascii_mode)
     bytes = read(buff)
-    Sys.isunix() && @test bytes == filter(!cr, download_bytes)
+    @test bytes == filter(!cr, download_bytes)
     Base.close(ftp)
 
     # upload

--- a/test/non_ssl.jl
+++ b/test/non_ssl.jl
@@ -204,11 +204,17 @@ end
 
 @testset "binary_ascii" begin
     # test binary vs ascii
-    Sys.isunix() && (upload_bytes = b"FooBar\nFooBar")
-    Sys.iswindows() && (upload_bytes = b"FooBar\r\nFooBar")
+    upload_bytes = if Sys.iswindows()
+        b"FooBar\r\nFooBar"
+    else
+        b"FooBar\nFooBar"
+    end
 
-    Sys.isunix() && (download_bytes = b"FooBar\r\nFooBar")
-    Sys.iswindows() && (download_bytes = b"FooBar\nFooBar\x1a\x1a\x1a")
+    download_bytes = if Sys.iswindows()
+        b"FooBar\nFooBar\x1a\x1a\x1a"
+    else
+        b"FooBar\r\nFooBar"
+    end
 
     # Detect carriage return
     cr(b::UInt8) = b == UInt8('\r')


### PR DESCRIPTION
As part of investigating https://github.com/invenia/FTPClient.jl/issues/91 I did some refactoring to make the tests easier to understand. This allowed me to fix the tests so they are compatible with FTPServer 0.3.0 / pyftpdlib 1.5.6.