### PR TITLE
Fix compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ URIParser = "30578b45-9adc-5946-b283-645ec420af67"
 [compat]
 FTPServer = "0.2.3"
 LibCURL = "0.5.1, 0.6"
+URIParser = "0.4"
 julia = "0.7, 1.0"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ URIParser = "30578b45-9adc-5946-b283-645ec420af67"
 
 [compat]
 FTPServer = "0.2.3"
-LibCURL = ">= 0.5.1"
+LibCURL = "0.5.1, 0.6"
 julia = "0.7, 1.0"
 
 [extras]


### PR DESCRIPTION
Addressing the following comment:

> Your new version pull request does not meet the following guidelines for auto-merging:
>
> * The following dependencies do not have a compat entry that has an upper bound: LibCURL, URIParser. You may find [CompatHelper](https://github.com/bcbi/CompatHelper.jl) helpful for keeping your compat entries up-to-date.Note: If your package works for the current version `x.y.z` of a dependency `foo`, then a compat entry `foo = x.y.z` implies a compatibility upper bound for packages following semver. You can additionally include earlier versions your package is compatible with. See [https://julialang.github.io/Pkg.jl/v1/compatibility/](https://julialang.github.io/Pkg.jl/v1/compatibility/) for details.
> 
> Note that the guidelines are only required for the pull request to be merged automatically. However, it is **strongly recommended** to follow them, since otherwise the pull request needs to be manually reviewed and merged by a human.

https://github.com/JuliaRegistries/General/pull/15184#issuecomment-632854537

I copied it here for reference as the bot deletes comments once they are addressed.