### PR TITLE
Require LibCURL 0.6.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ URIParser = "30578b45-9adc-5946-b283-645ec420af67"
 
 [compat]
 FTPServer = "0.3"
-LibCURL = "0.6"
+LibCURL = "0.6.1"
 URIParser = "0.4"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "FTPClient"
 uuid = "01fcc997-4f28-56b8-8a06-30002c134abb"
-version = "1.2.0"
+version = "1.2.1"
 
 [deps]
 LibCURL = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"


### PR DESCRIPTION
Ensures that end users cannot run into issues with making system images. See https://github.com/JuliaWeb/LibCURL.jl/pull/84 for details.