### PR TITLE
Pin python to fix compatibility with pyftpdlib and silence ASCII failures

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,6 +45,22 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - if: matrix.os != 'windows-latest'
+        run: |
+          python3.8 -m pip install --upgrade pip setuptools
+          python3.8 -m pip install pyopenssl pyftpdlib
+      - if: matrix.os != 'windows-latest' && matrix.arch != 'x86'
+        run: |
+          echo "PYTHON=$pythonLocation/bin/python3.8" >> $GITHUB_ENV
+      - if: matrix.os != 'windows-latest' && matrix.arch == 'x86'
+        run: |
+          echo "PYTHON=''" >> $GITHUB_ENV
+      # Windows uses different python syntax
+      - if: matrix.os == 'windows-latest'
+        run: |
+          py -3.8 -m pip install --upgrade pip setuptools
+          py -3.8 -m pip install pyopenssl pyftpdlib
+          echo "PYTHON=$env:pythonLocation\python.exe" >> $env:GITHUB_ENV
       - uses: actions/cache@v2
         env:
           cache-name: cache-artifacts
@@ -57,9 +73,9 @@ jobs:
             ${{ runner.os }}-${{ matrix.arch }}-
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@latest
-      - uses: julia-actions/julia-runtest@latest
         env:
-          PYTHON: ''  # For use with the FTPServer.jl test dependency
+          CONDA_JL_VERSION: '3'
+      - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,9 @@ jobs:
             arch: x64
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'  # pyftpdlib is not currently compatible with Python 3.9
       - uses: julia-actions/setup-julia@v1
         with:
           version: ${{ matrix.version }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,9 +32,9 @@ jobs:
           - os: windows-latest
             arch: x86
         include:
-          # Add a 1.5 job because that's what Invenia actually uses
+          # Add a 1.6 job because that's what Invenia actually uses
           - os: ubuntu-latest
-            version: 1.5
+            version: 1.6
             arch: x64
     steps:
       - uses: actions/checkout@v2

--- a/test/non_ssl.jl
+++ b/test/non_ssl.jl
@@ -231,10 +231,10 @@ end
 
     # Our implementation currently checks size which does not work in ASCII mode on FTPServer
     # https://github.com/invenia/FTPClient.jl/issues/113
-    @test_skip begin
+    @test_broken begin
         resp = ftp_get(options, byte_file; mode=ascii_mode)
         bytes = read(resp.body)
-        @test bytes == filter(!cr, download_bytes)
+        bytes == filter(!cr, download_bytes)
     end
 
     # it is the same file when downloading in binary mode
@@ -244,10 +244,10 @@ end
 
     # it is not the same file when downloading in ascii mode
     ctxt, resp = ftp_connect(options)
-    @test_skip begin  # https://github.com/invenia/FTPClient.jl/issues/113
+    @test_broken begin  # https://github.com/invenia/FTPClient.jl/issues/113
         resp = ftp_get(ctxt, byte_file, mode=ascii_mode)
         bytes = read(resp.body)
-        @test bytes == filter(!cr, download_bytes)
+        bytes == filter(!cr, download_bytes)
     end
     ftp_close_connection(ctxt)
 
@@ -260,10 +260,10 @@ end
 
     # it is not the same file when downloading in ascii mode
     ftp = FTP(; opts...)
-    @test_skip begin  # https://github.com/invenia/FTPClient.jl/issues/113
+    @test_broken begin  # https://github.com/invenia/FTPClient.jl/issues/113
         buff = download(ftp, byte_file, mode=ascii_mode)
         bytes = read(buff)
-        @test bytes == filter(!cr, download_bytes)
+        bytes == filter(!cr, download_bytes)
     end
     Base.close(ftp)
 
@@ -275,19 +275,23 @@ end
     Base.close(ftp)
 
     # binary file download using ftp object, start in ascii, and switch to binary, then back
-    @test_skip begin  # https://github.com/invenia/FTPClient.jl/issues/113
-        ftp = FTP(; opts...)
+    ftp = FTP(; opts...)
+    @test_broken begin  # https://github.com/invenia/FTPClient.jl/issues/113
         buff = download(ftp, byte_file, mode=ascii_mode)
         bytes = read(buff)
-        @test bytes == filter(!cr, download_bytes)
-        buff = download(ftp, byte_file)
-        bytes = read(buff)
-        @test bytes == download_bytes
-        buff = download(ftp, byte_file, mode=ascii_mode)
-        bytes = read(buff)
-        @test bytes == filter(!cr, download_bytes)
-        Base.close(ftp)
+        bytes == filter(!cr, download_bytes)
     end
+
+    buff = download(ftp, byte_file)
+    bytes = read(buff)
+    @test bytes == download_bytes
+
+    @test_broken begin  # https://github.com/invenia/FTPClient.jl/issues/113
+        buff = download(ftp, byte_file, mode=ascii_mode)
+        bytes = read(buff)
+        bytes == filter(!cr, download_bytes)
+    end
+    Base.close(ftp)
 
     # upload
     server_byte_file = joinpath(HOMEDIR, byte_upload_file)

--- a/test/non_ssl.jl
+++ b/test/non_ssl.jl
@@ -228,9 +228,14 @@ end
 
     # it is not the same file when downloading in ascii mode
     options = RequestOptions(; opts..., ssl=false, active_mode=false)
-    resp = ftp_get(options, byte_file; mode=ascii_mode)
-    bytes = read(resp.body)
-    @test bytes == filter(!cr, download_bytes)
+
+    # Our implementation currently checks size which does not work in ASCII mode on FTPServer
+    # https://github.com/invenia/FTPClient.jl/issues/113
+    @test_skip begin
+        resp = ftp_get(options, byte_file; mode=ascii_mode)
+        bytes = read(resp.body)
+        @test bytes == filter(!cr, download_bytes)
+    end
 
     # it is the same file when downloading in binary mode
     resp = ftp_get(options, byte_file)
@@ -239,9 +244,11 @@ end
 
     # it is not the same file when downloading in ascii mode
     ctxt, resp = ftp_connect(options)
-    resp = ftp_get(ctxt, byte_file, mode=ascii_mode)
-    bytes = read(resp.body)
-    @test bytes == filter(!cr, download_bytes)
+    @test_skip begin  # https://github.com/invenia/FTPClient.jl/issues/113
+        resp = ftp_get(ctxt, byte_file, mode=ascii_mode)
+        bytes = read(resp.body)
+        @test bytes == filter(!cr, download_bytes)
+    end
     ftp_close_connection(ctxt)
 
     # it is the same file when downloading in binary mode
@@ -253,9 +260,11 @@ end
 
     # it is not the same file when downloading in ascii mode
     ftp = FTP(; opts...)
-    buff = download(ftp, byte_file, mode=ascii_mode)
-    bytes = read(buff)
-    @test bytes == filter(!cr, download_bytes)
+    @test_skip begin  # https://github.com/invenia/FTPClient.jl/issues/113
+        buff = download(ftp, byte_file, mode=ascii_mode)
+        bytes = read(buff)
+        @test bytes == filter(!cr, download_bytes)
+    end
     Base.close(ftp)
 
     # it is the same file when downloading in binary mode
@@ -266,17 +275,19 @@ end
     Base.close(ftp)
 
     # binary file download using ftp object, start in ascii, and switch to binary, then back
-    ftp = FTP(; opts...)
-    buff = download(ftp, byte_file, mode=ascii_mode)
-    bytes = read(buff)
-    @test bytes == filter(!cr, download_bytes)
-    buff = download(ftp, byte_file)
-    bytes = read(buff)
-    @test bytes == download_bytes
-    buff = download(ftp, byte_file, mode=ascii_mode)
-    bytes = read(buff)
-    @test bytes == filter(!cr, download_bytes)
-    Base.close(ftp)
+    @test_skip begin  # https://github.com/invenia/FTPClient.jl/issues/113
+        ftp = FTP(; opts...)
+        buff = download(ftp, byte_file, mode=ascii_mode)
+        bytes = read(buff)
+        @test bytes == filter(!cr, download_bytes)
+        buff = download(ftp, byte_file)
+        bytes = read(buff)
+        @test bytes == download_bytes
+        buff = download(ftp, byte_file, mode=ascii_mode)
+        bytes = read(buff)
+        @test bytes == filter(!cr, download_bytes)
+        Base.close(ftp)
+    end
 
     # upload
     server_byte_file = joinpath(HOMEDIR, byte_upload_file)


### PR DESCRIPTION
Temporarily pin python to 3.8 to get CI tests running again. This does not make tests pass but at least gets us back to the previous LibCURL-related errors.

Skips tests for ASCII that don't work with our test server (but might with other FTP server implementations).