### PR TITLE
Escape special chars in username/password to avoid building incorrect URIs

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,11 +5,13 @@ version = "1.2.2"
 [deps]
 LibCURL = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
 URIParser = "30578b45-9adc-5946-b283-645ec420af67"
+URIs = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
 
 [compat]
 FTPServer = "0.3"
 LibCURL = "0.6.1"
 URIParser = "0.4"
+URIs = "1.6.1"
 julia = "1.3"
 
 [extras]

--- a/src/FTPClient.jl
+++ b/src/FTPClient.jl
@@ -1,6 +1,7 @@
 module FTPClient
 
 using URIParser: URI
+using URIs: escapeuri
 
 mutable struct FTPClientError <: Exception
     msg::AbstractString

--- a/src/FTPObject.jl
+++ b/src/FTPObject.jl
@@ -41,7 +41,7 @@ function FTP(;
     verbose::Union{Bool,IOStream}=false,
 )
     options = RequestOptions(
-        username=username, password=password, hostname=hostname, port=port,
+        username=escapeuri(username), password=escapeuri(password), hostname=hostname, port=port,
         ssl=ssl, implicit=implicit, verify_peer=verify_peer, active_mode=active_mode,
     )
 

--- a/src/conn_context.jl
+++ b/src/conn_context.jl
@@ -142,7 +142,7 @@ function ftp_get(
         @ce_curl curl_easy_setopt CURLOPT_PROXY_TRANSFER_MODE Int64(1)
 
         ftp_url = url(ctxt)
-        full_url = ftp_url * file_name
+        full_url = ftp_url * escapeuri(file_name)
         if mode == binary_mode
             @ce_curl curl_easy_setopt CURLOPT_URL full_url * ";type=i"
         elseif mode == ascii_mode
@@ -210,7 +210,7 @@ function ftp_put(
     @ce_curl curl_easy_setopt CURLOPT_READFUNCTION C_CURL_READ_CB[]
 
     ftp_url = url(ctxt)
-    @ce_curl curl_easy_setopt CURLOPT_URL ftp_url * file_name
+    @ce_curl curl_easy_setopt CURLOPT_URL ftp_url * escapeuri(file_name)
 
     if mode == binary_mode
         @ce_curl curl_easy_setopt CURLOPT_TRANSFERTEXT Int64(0)

--- a/test/ftp_object.jl
+++ b/test/ftp_object.jl
@@ -18,6 +18,19 @@ function no_unexpected_changes(ftp::FTP, url::AbstractString=FTPClient.trailing(
     close(other)
 end
 
+function test_parseable_uri(; kwargs...)
+    opts_nt = (; kwargs...)
+    ftp = FTP(; opts_nt...)
+    uri = URI(ftp.ctxt.url)
+    @test uri.host == opts_nt.hostname
+    @test uri.port == string(opts_nt.port)
+
+    userinfo = split(uri.userinfo, ":")
+    @test unescapeuri(get(userinfo, 1, "")) == opts_nt.username
+    @test unescapeuri(get(userinfo, 2, "")) == opts_nt.password
+    close(ftp)
+end
+
 function expected_output(active::Bool)
     mode = active ? "active" : "passive"
     expected = """
@@ -90,6 +103,18 @@ end
     # Validate that FTP is treated as a scalar during broadcasting
     ftp = FTP(; opts...)
     @test size(ftp .== ftp) == ()
+end
+
+@testset "parseable url" begin
+    @testset "default case" begin
+        test_parseable_uri(; opts...)
+    end
+    @testset "user name with special chars" begin
+        test_parseable_uri(; opts..., username="john.doe@example.com")
+    end
+    @testset "password with special chars" begin
+        test_parseable_uri(; opts..., password="p@ss:word")
+    end
 end
 
 @testset "connection with url" begin
@@ -498,6 +523,18 @@ end
         end
         @test num_bytes > 0
         @test read(buffer, String) == read(joinpath(HOMEDIR, download_file), String)
+        no_unexpected_changes(ftp)
+        close(ftp)
+    end
+
+    @testset "download with spaces in file name" begin
+        local ftp, buffer
+        num_bytes = captured_size() do io
+            ftp = FTP(; opts..., verbose=io)
+            buffer = download(ftp, download_file_2)
+        end
+        @test num_bytes > 0
+        @test read(buffer, String) == read(joinpath(HOMEDIR, download_file_2), String)
         no_unexpected_changes(ftp)
         close(ftp)
     end

--- a/test/non_ssl.jl
+++ b/test/non_ssl.jl
@@ -231,7 +231,7 @@ end
 
     # Our implementation currently checks size which does not work in ASCII mode on FTPServer
     # https://github.com/invenia/FTPClient.jl/issues/113
-    @test_broken begin
+    @test begin
         resp = ftp_get(options, byte_file; mode=ascii_mode)
         bytes = read(resp.body)
         bytes == filter(!cr, download_bytes)
@@ -244,7 +244,7 @@ end
 
     # it is not the same file when downloading in ascii mode
     ctxt, resp = ftp_connect(options)
-    @test_broken begin  # https://github.com/invenia/FTPClient.jl/issues/113
+    @test begin  # https://github.com/invenia/FTPClient.jl/issues/113
         resp = ftp_get(ctxt, byte_file, mode=ascii_mode)
         bytes = read(resp.body)
         bytes == filter(!cr, download_bytes)
@@ -260,7 +260,7 @@ end
 
     # it is not the same file when downloading in ascii mode
     ftp = FTP(; opts...)
-    @test_broken begin  # https://github.com/invenia/FTPClient.jl/issues/113
+    @test begin  # https://github.com/invenia/FTPClient.jl/issues/113
         buff = download(ftp, byte_file, mode=ascii_mode)
         bytes = read(buff)
         bytes == filter(!cr, download_bytes)
@@ -276,7 +276,7 @@ end
 
     # binary file download using ftp object, start in ascii, and switch to binary, then back
     ftp = FTP(; opts...)
-    @test_broken begin  # https://github.com/invenia/FTPClient.jl/issues/113
+    @test begin  # https://github.com/invenia/FTPClient.jl/issues/113
         buff = download(ftp, byte_file, mode=ascii_mode)
         bytes = read(buff)
         bytes == filter(!cr, download_bytes)
@@ -286,7 +286,7 @@ end
     bytes = read(buff)
     @test bytes == download_bytes
 
-    @test_broken begin  # https://github.com/invenia/FTPClient.jl/issues/113
+    @test begin  # https://github.com/invenia/FTPClient.jl/issues/113
         buff = download(ftp, byte_file, mode=ascii_mode)
         bytes = read(buff)
         bytes == filter(!cr, download_bytes)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Test
 using FTPClient
 using FTPServer
 using FTPServer: username, password, hostname, port, HOMEDIR, tempfile
+using URIs
 
 # FTP code for when the file transfer is complete.
 const complete_transfer_code = 226
@@ -23,6 +24,7 @@ upload_file_3 = "test_upload_3.txt"
 upload_file_4 = "test_upload_4.txt"
 
 download_file = "test_download.txt"
+download_file_2 = "test download:2.txt"
 
 @testset "all_tests" begin
 
@@ -33,7 +35,10 @@ download_file = "test_download.txt"
         tempfile(upload_file_4)
 
         tempfile(joinpath(HOMEDIR, download_file))
+        tempfile(joinpath(HOMEDIR, download_file_2))
+
         cleanup_file(download_file)
+        cleanup_file(download_file_2)
         cleanup_file(joinpath(HOMEDIR, upload_file))
 
         @testset "All Tests" begin


### PR DESCRIPTION
When either the username or password contains special chars (such as `@` or `:`), these have to be escaped in order for the FTP URI to be correctly parseable (both by the remote FTP server, and downstream `FTPClient.jl` functions, such as `safe_uri`)

This PR does that when the `FTP` object is built with individual keyword arguments. A similar problem occurs when building the `FTP` object with an uri (#111) but it could be argued that in this case it is the user's responsibility to provide a parseable URI in which problematic characters have already been escaped.